### PR TITLE
refactor: remove nominatorCount from operator components and related

### DIFF
--- a/apps/web/src/components/operators/OperatorCard.tsx
+++ b/apps/web/src/components/operators/OperatorCard.tsx
@@ -67,16 +67,12 @@ export const OperatorCard: React.FC<OperatorCardProps> = ({ operator, onStake, o
         </div>
 
         {/* Pool Stats */}
-        <div className="grid grid-cols-2 gap-4 mb-4 p-3 bg-muted rounded-lg">
-          <div>
+        <div className="mb-4 p-3 bg-muted rounded-lg">
+          <div className="text-center">
             <div className="text-sm font-medium text-foreground font-mono">
               {formatNumber(operator.totalStaked)} AI3
             </div>
             <div className="text-xs text-muted-foreground">Total Staked</div>
-          </div>
-          <div>
-            <div className="text-sm font-medium text-foreground">{operator.nominatorCount}</div>
-            <div className="text-xs text-muted-foreground">Nominators</div>
           </div>
         </div>
 

--- a/apps/web/src/components/operators/OperatorDetailsHeader.tsx
+++ b/apps/web/src/components/operators/OperatorDetailsHeader.tsx
@@ -70,16 +70,12 @@ export const OperatorDetailsHeader: React.FC<OperatorDetailsHeaderProps> = ({
         </div>
 
         {/* Key Metrics Grid */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-6">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 mb-6">
           <div className="text-center">
             <p className="text-2xl font-bold text-code">
               {formatPercentage(operator.nominationTax)}
             </p>
             <p className="text-body-small text-muted-foreground">Tax</p>
-          </div>
-          <div className="text-center">
-            <p className="text-2xl font-bold text-code">{operator.nominatorCount}</p>
-            <p className="text-body-small text-muted-foreground">Nominators</p>
           </div>
           <div className="text-center">
             <p className="text-2xl font-bold text-code">{formatNumber(operator.totalStaked)} AI3</p>

--- a/apps/web/src/components/operators/OperatorTable.tsx
+++ b/apps/web/src/components/operators/OperatorTable.tsx
@@ -152,13 +152,8 @@ export const OperatorTable: React.FC<OperatorTableProps> = ({
                 <span className="font-mono">{formatPercentage(operator.nominationTax)}</span>
               </td>
               <td className="p-4">
-                <div>
-                  <div className="font-mono font-medium">
-                    {formatNumber(operator.totalStaked)} AI3
-                  </div>
-                  <div className="text-sm text-muted-foreground">
-                    {operator.nominatorCount} nominators
-                  </div>
+                <div className="font-mono font-medium">
+                  {formatNumber(operator.totalStaked)} AI3
                 </div>
               </td>
               <td className="p-4">

--- a/apps/web/src/components/staking/OperatorSummary.tsx
+++ b/apps/web/src/components/staking/OperatorSummary.tsx
@@ -65,14 +65,10 @@ export const OperatorSummary: React.FC<OperatorSummaryProps> = ({ operator }) =>
           <Badge variant={getStatusBadgeVariant(operator.status)}>{operator.status}</Badge>
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
           <div className="text-center">
             <p className="text-2xl font-bold text-code">{operator.nominationTax}%</p>
             <p className="text-body-small text-muted-foreground">Tax Rate</p>
-          </div>
-          <div className="text-center">
-            <p className="text-2xl font-bold text-code">{operator.nominatorCount}</p>
-            <p className="text-body-small text-muted-foreground">Nominators</p>
           </div>
           <div className="text-center">
             <p className="text-2xl font-bold text-code">{calculateUserShare()}%</p>
@@ -122,7 +118,7 @@ export const OperatorSummary: React.FC<OperatorSummaryProps> = ({ operator }) =>
 
         <div className="mt-4 pt-4 border-t border-border">
           <p className="text-body-small text-muted-foreground">
-            <span className="font-medium">{operator.nominatorCount} nominators</span> • Min stake:{' '}
+            Min stake:{' '}
             <span className="text-code">
               {formatAI3AmountWithCommas(parseFloat(operator.minimumNominatorStake))} AI3
             </span>

--- a/apps/web/src/lib/operator-mapper.ts
+++ b/apps/web/src/lib/operator-mapper.ts
@@ -34,7 +34,6 @@ export const mapIndexerToOperator = (
     minimumNominatorStake: minimumStake,
     status: 'active' as const, // TODO: Derive from operator status in indexer
     totalStaked,
-    nominatorCount: 0, // TODO: Get from nominators query
   };
 };
 
@@ -69,6 +68,5 @@ export const mapRpcToOperator = (
     minimumNominatorStake: minimumStake,
     status: 'active' as const,
     totalStaked,
-    nominatorCount: 0,
   };
 };

--- a/apps/web/src/services/operator-service.ts
+++ b/apps/web/src/services/operator-service.ts
@@ -52,7 +52,6 @@ export const operatorService = async (networkId: string = config.network.default
         sharePrice: '1.0000',
         totalShares: totalStaked,
         totalStaked,
-        nominatorCount: operators.reduce((sum, op) => sum + op.nominatorCount, 0),
       };
     } catch (error) {
       console.error('Failed to fetch operator stats:', error);
@@ -60,7 +59,6 @@ export const operatorService = async (networkId: string = config.network.default
         sharePrice: '1.0000',
         totalShares: '0',
         totalStaked: '0',
-        nominatorCount: 0,
       };
     }
   };

--- a/apps/web/src/types/indexer.ts
+++ b/apps/web/src/types/indexer.ts
@@ -89,5 +89,4 @@ export interface IndexerToOperatorMapping {
   minimumNominatorStake: string; // minimum_nominator_stake (converted from wei)
   status: 'active' | 'inactive' | 'slashed' | 'degraded'; // derived
   totalStaked: string; // needs RPC fallback or separate query
-  nominatorCount: number; // needs separate query
 }

--- a/apps/web/src/types/operator.ts
+++ b/apps/web/src/types/operator.ts
@@ -12,14 +12,12 @@ export interface Operator {
   // Current Status
   status: 'active' | 'inactive' | 'slashed' | 'degraded';
   totalStaked: string; // Total AI3 in pool
-  nominatorCount: number;
 }
 
 export interface OperatorStats {
   sharePrice: string;
   totalShares: string;
   totalStaked: string;
-  nominatorCount: number;
 }
 
 export type FilterState = {


### PR DESCRIPTION
This pull request removes the display and calculation of the `nominatorCount` property for operators throughout the codebase. The change simplifies both the UI and the underlying data models by eliminating the nominators count from operator summaries, cards, tables, and related type definitions.
