### PR TITLE
Disable wallet-dependent features when wallet not connected

### DIFF
--- a/apps/web/src/components/operators/OperatorActions.tsx
+++ b/apps/web/src/components/operators/OperatorActions.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { useWallet } from '@/hooks/use-wallet';
 import type { Operator } from '@/types/operator';
 import type { UserPosition } from '@/types/position';
 
@@ -12,6 +13,7 @@ interface OperatorActionsProps {
 
 export const OperatorActions: React.FC<OperatorActionsProps> = ({ operator, userPosition }) => {
   const navigate = useNavigate();
+  const { isConnected } = useWallet();
 
   const handleStake = () => {
     navigate(`/staking/${operator.id}`);
@@ -23,17 +25,14 @@ export const OperatorActions: React.FC<OperatorActionsProps> = ({ operator, user
 
   const hasPosition = userPosition && userPosition.positionValue > 0;
   const isOperatorActive = operator.status === 'active';
+  const canStake = isConnected && isOperatorActive;
+  const canWithdraw = isConnected && hasPosition;
 
   return (
     <Card>
       <CardContent className="pt-6">
         <div className="flex flex-col sm:flex-row gap-4">
-          <Button
-            className="flex-1 font-sans"
-            onClick={handleStake}
-            disabled={!isOperatorActive}
-            size="lg"
-          >
+          <Button className="flex-1 font-sans" onClick={handleStake} disabled={!canStake} size="lg">
             {hasPosition ? 'Add More Stake' : 'Stake to this Operator'}
           </Button>
 
@@ -42,6 +41,7 @@ export const OperatorActions: React.FC<OperatorActionsProps> = ({ operator, user
               variant="outline"
               className="flex-1 font-sans"
               onClick={handleWithdraw}
+              disabled={!canWithdraw}
               size="lg"
             >
               Withdraw Stake
@@ -49,7 +49,12 @@ export const OperatorActions: React.FC<OperatorActionsProps> = ({ operator, user
           )}
         </div>
 
-        {!isOperatorActive && (
+        {!isConnected && (
+          <p className="text-body-small text-muted-foreground mt-4 text-center">
+            <span className="font-medium">Connect your wallet</span> to stake or withdraw tokens.
+          </p>
+        )}
+        {isConnected && !isOperatorActive && (
           <p className="text-body-small text-muted-foreground mt-4 text-center">
             This operator is currently <span className="font-medium">{operator.status}</span> and
             not accepting new stakes.

--- a/apps/web/src/components/positions/ActivePositionsTable.tsx
+++ b/apps/web/src/components/positions/ActivePositionsTable.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
 import { usePositions } from '@/hooks/use-positions';
+import { useWallet } from '@/hooks/use-wallet';
 import { formatAI3, formatTimeAgo } from '@/lib/formatting';
 import { PositionBreakdown } from './PositionBreakdown';
 import type { UserPosition } from '@/types/position';
@@ -20,6 +21,7 @@ interface PositionRowProps {
   onOperatorClick?: (operatorId: string) => void;
   onWithdrawClick?: (position: UserPosition) => void;
   onAddStakeClick?: (position: UserPosition) => void;
+  isWalletConnected: boolean;
 }
 
 const PositionRow: React.FC<PositionRowProps> = ({
@@ -27,6 +29,7 @@ const PositionRow: React.FC<PositionRowProps> = ({
   onOperatorClick,
   onWithdrawClick,
   onAddStakeClick,
+  isWalletConnected,
 }) => {
   const getStatusVariant = (status: UserPosition['status']) => {
     switch (status) {
@@ -123,6 +126,7 @@ const PositionRow: React.FC<PositionRowProps> = ({
               variant="outline"
               size="sm"
               onClick={() => onAddStakeClick(position)}
+              disabled={!isWalletConnected}
               className="text-xs font-sans text-primary hover:text-primary/80 border-primary/20 hover:border-primary/40"
             >
               Add Stake
@@ -133,6 +137,7 @@ const PositionRow: React.FC<PositionRowProps> = ({
               variant="outline"
               size="sm"
               onClick={() => onWithdrawClick(position)}
+              disabled={!isWalletConnected}
               className="text-xs font-sans text-warning-600 hover:text-warning-700 border-warning-200 hover:border-warning-300"
             >
               Withdraw
@@ -153,6 +158,7 @@ export const ActivePositionsTable: React.FC<ActivePositionsTableProps> = ({
     refreshInterval,
     networkId,
   });
+  const { isConnected } = useWallet();
   const navigate = useNavigate();
 
   const handleWithdrawClick = (position: UserPosition) => {
@@ -236,6 +242,7 @@ export const ActivePositionsTable: React.FC<ActivePositionsTableProps> = ({
                 onOperatorClick={onOperatorClick}
                 onWithdrawClick={handleWithdrawClick}
                 onAddStakeClick={handleAddStakeClick}
+                isWalletConnected={isConnected}
               />
             ))}
           </div>

--- a/apps/web/src/components/staking/StakingForm.tsx
+++ b/apps/web/src/components/staking/StakingForm.tsx
@@ -217,21 +217,23 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
                 ) : balance ? (
                   formatAI3(balance.free)
                 ) : (
-                  <span className="text-warning">Wallet not connected</span>
+                  <span className="text-warning-700">Wallet not connected</span>
                 )}
               </span>
             </div>
           </div>
 
           {/* Amount Input */}
-          <AmountInput
-            amount={formState.amount}
-            onAmountChange={handleAmountChange}
-            errors={formState.errors}
-            disabled={formState.isSubmitting}
-            availableBalance={balance ? parseFloat(balance.free) : 0}
-            estimatedFee={estimatedFee ?? undefined}
-          />
+          <div className={!isConnected ? 'opacity-60' : ''}>
+            <AmountInput
+              amount={formState.amount}
+              onAmountChange={handleAmountChange}
+              errors={isConnected ? formState.errors : []}
+              disabled={!isConnected || formState.isSubmitting}
+              availableBalance={balance ? parseFloat(balance.free) : 0}
+              estimatedFee={estimatedFee ?? undefined}
+            />
+          </div>
 
           {/* Transaction Status */}
           {txHash && (

--- a/apps/web/src/components/staking/StakingForm.tsx
+++ b/apps/web/src/components/staking/StakingForm.tsx
@@ -7,6 +7,7 @@ import { TransactionPreview } from '@/components/transaction';
 import { useBalance } from '@/hooks/use-balance';
 import { usePositions, useOperatorPosition } from '@/hooks/use-positions';
 import { useStakingTransaction } from '@/hooks/use-staking-transaction';
+import { useWallet } from '@/hooks/use-wallet';
 import { formatAI3 } from '@/lib/formatting';
 import type { Operator } from '@/types/operator';
 import type { StakingFormState, StakingCalculations } from '@/types/staking';
@@ -27,6 +28,7 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
   const { balance, loading: balanceLoading } = useBalance();
   const { refetch: refetchPositions } = usePositions({ refreshInterval: 0 });
   const { position: currentPosition } = useOperatorPosition(operator.id);
+  const { isConnected } = useWallet();
   const {
     execute,
     isSigning,
@@ -196,6 +198,15 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
             </div>
           )}
 
+          {/* Wallet Connection Alert */}
+          {!isConnected && (
+            <Alert variant="warning">
+              <AlertDescription>
+                Connect your wallet to stake tokens with this operator
+              </AlertDescription>
+            </Alert>
+          )}
+
           {/* Available Balance */}
           <div className="p-4 bg-accent/10 rounded-lg">
             <div className="flex justify-between items-center">
@@ -206,7 +217,7 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
                 ) : balance ? (
                   formatAI3(balance.free)
                 ) : (
-                  'Connect wallet'
+                  <span className="text-warning">Wallet not connected</span>
                 )}
               </span>
             </div>
@@ -280,9 +291,13 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
                   disabled={!formState.isValid || formState.isSubmitting || !canExecute}
                   className="flex-1"
                 >
-                  {isSigning && 'Awaiting signature...'}
-                  {isPending && 'Submitting...'}
-                  {!stakingLoading && 'Stake Tokens'}
+                  {isSigning
+                    ? 'Awaiting signature...'
+                    : isPending
+                      ? 'Submitting...'
+                      : !isConnected
+                        ? 'Connect Wallet to Stake'
+                        : 'Stake Tokens'}
                 </Button>
               </>
             )}

--- a/apps/web/src/components/staking/WithdrawalForm.tsx
+++ b/apps/web/src/components/staking/WithdrawalForm.tsx
@@ -27,7 +27,7 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
   const [withdrawalMethod, setWithdrawalMethod] = useState<WithdrawalMethod>('partial');
   const [amount, setAmount] = useState<number>(0);
   const { operators } = useOperators();
-  const { selectedAccount } = useWallet();
+  const { selectedAccount, isConnected } = useWallet();
 
   const {
     executeWithdraw,
@@ -155,6 +155,15 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
           </div>
         </CardHeader>
         <CardContent className="stack-lg">
+          {/* Wallet Connection Alert */}
+          {!isConnected && (
+            <Alert variant="warning">
+              <AlertDescription>
+                Connect your wallet to withdraw tokens from this position
+              </AlertDescription>
+            </Alert>
+          )}
+
           {/* Withdrawal Method Selection */}
           <div className="stack-sm">
             <label className="text-label">Withdrawal Method</label>
@@ -265,9 +274,11 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
                 ? 'Signing...'
                 : withdrawalState === 'pending'
                   ? 'Broadcasting...'
-                  : validationResult.willWithdrawAll
-                    ? 'Withdraw All Tokens'
-                    : 'Withdraw Tokens'}
+                  : !isConnected
+                    ? 'Connect Wallet to Withdraw'
+                    : validationResult.willWithdrawAll
+                      ? 'Withdraw All Tokens'
+                      : 'Withdraw Tokens'}
             </Button>
           </div>
         </CardContent>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,11 +1,13 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
 import { PositionSummary, ActivePositionsTable, PendingOperations } from '@/components/positions';
+import { WalletModal } from '@/components/wallet';
 import { useBalance } from '@/hooks/use-balance';
 import { usePositions } from '@/hooks/use-positions';
+import { useWallet } from '@/hooks/use-wallet';
 import { formatAI3 } from '@/lib/formatting';
 import { layout } from '@/lib/layout';
 
@@ -13,6 +15,8 @@ export const DashboardPage: React.FC = () => {
   const navigate = useNavigate();
   const { balance, loading: balanceLoading } = useBalance();
   const { hasPositions, portfolioSummary } = usePositions();
+  const { isConnected } = useWallet();
+  const [walletModalOpen, setWalletModalOpen] = useState(false);
 
   // Calculate true total balance including storage deposits
   const totalBalanceWithPositions = useMemo(() => {
@@ -138,15 +142,24 @@ export const DashboardPage: React.FC = () => {
             <div className="text-center">
               <CardTitle className="text-h3 mb-2">Start Staking</CardTitle>
               <CardDescription className="text-body mb-4">
-                Browse available operators and choose the best fit for your staking strategy
+                {isConnected
+                  ? 'Browse available operators and choose the best fit for your staking strategy'
+                  : 'Connect your wallet to start staking with operators'}
               </CardDescription>
-              <Button size="lg" onClick={() => navigate('/operators')}>
-                Browse Operators
+              <Button
+                size="lg"
+                onClick={
+                  isConnected ? () => navigate('/operators') : () => setWalletModalOpen(true)
+                }
+              >
+                {isConnected ? 'Browse Operators' : 'Connect Wallet'}
               </Button>
             </div>
           </CardContent>
         </Card>
       )}
+
+      <WalletModal open={walletModalOpen} onOpenChange={setWalletModalOpen} />
     </div>
   );
 };


### PR DESCRIPTION
### Summary

This PR gates staking- and withdrawal-related actions behind wallet connection status, while keeping operator exploration open. Users can navigate into the staking/withdrawal flows from the operators list, and are clearly guided to connect their wallet within those flows. Closes #73 

### Highlights

- **Clear guidance**: Alerts and button labels explicitly prompt connection when required.
- **Predictable controls**: Inputs and action buttons are disabled only when they cannot function.
- **Design-token aligned**: Uses semantic tokens (e.g., `text-warning-700`) and existing utility classes.

### Changes by area

- **Operator actions**
  - `OperatorActions`: Disable Stake/Withdraw when disconnected; add helper text.
  - `ActivePositionsTable`: Disable row-level Add Stake/Withdraw when disconnected.

- **Staking flow** (`StakingForm`)
  - Warning alert when disconnected
  - Balance area shows “Wallet not connected” (`text-warning-700`)
  - Amount input is disabled and visually muted; validation errors are suppressed while disconnected
  - Primary button label becomes “Connect Wallet to Stake” when disconnected

- **Withdrawal flow** (`WithdrawalForm`)
  - Warning alert when disconnected
  - Primary button label becomes “Connect Wallet to Withdraw” when disconnected

- **Dashboard CTA** (`DashboardPage`)
  - Disconnected: “Connect Wallet” opens modal
  - Connected: “Browse Operators” navigates

### Non-functional / Architecture

- **No changes** to store or transaction logic; execution remains guarded by hooks such as `canExecute` and `canExecuteWithdrawal`.
- Tokens updated for consistency; no hard-coded colors were introduced.

### Motivation

- Resolves [Issue #73](https://github.com/autonomys/auto-portal/issues/73): previously, users could begin flows without clear connection requirements.
- Improves clarity, reduces dead-ends, and maintains smooth discovery.

### Testing checklist

1. Operators page (disconnected): Stake navigates to staking; staking shows alert, disabled input, and connect label.
2. Operator details (disconnected): Stake/Withdraw are disabled with helper text.
3. Active positions (disconnected): Row actions disabled.
4. Dashboard (disconnected): CTA opens wallet modal; connected → Browse Operators.
5. After connecting: All actions enable; staking/withdrawal execute as before.

