### PR TITLE
Fix withdrawal flow, surface transaction hash, and update “Storage Fund” terminology

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@apollo/client": "^3.8.10",
-    "@autonomys/auto-consensus": "1.5.10",
-    "@autonomys/auto-utils": "1.5.10",
+    "@autonomys/auto-consensus": "1.5.14",
+    "@autonomys/auto-utils": "1.5.14",
     "@polkadot/api": "^16.2.2",
     "@polkadot/extension-dapp": "^0.60.1",
     "@radix-ui/react-dialog": "^1.1.14",

--- a/apps/web/src/components/operators/OperatorDetailsHeader.tsx
+++ b/apps/web/src/components/operators/OperatorDetailsHeader.tsx
@@ -118,7 +118,7 @@ export const OperatorDetailsHeader: React.FC<OperatorDetailsHeaderProps> = ({
                 </div>
               )}
               <div className="flex justify-between items-center">
-                <span className="text-label text-muted-foreground">Storage Fee:</span>
+                <span className="text-label text-muted-foreground">Storage Fund:</span>
                 <span className="text-code font-medium">
                   {formatNumber((userPosition.positionValue * 0.2).toString())} AI3
                 </span>

--- a/apps/web/src/components/positions/ActivePositionsTable.tsx
+++ b/apps/web/src/components/positions/ActivePositionsTable.tsx
@@ -57,7 +57,7 @@ const PositionRow: React.FC<PositionRowProps> = ({
     }
   };
 
-  // Calculate total position value including storage fee deposit
+  // Calculate total position value including storage fund deposit
   const totalPositionValue = position.positionValue + position.storageFeeDeposit;
 
   return (
@@ -73,7 +73,7 @@ const PositionRow: React.FC<PositionRowProps> = ({
         {/* Position Details */}
         <div className="grid grid-cols-2 gap-4 text-sm text-muted-foreground font-sans">
           <div>
-            <span className="block text-xs text-muted-foreground">Storage Fee</span>
+            <span className="block text-xs text-muted-foreground">Storage Fund</span>
             <span className="font-mono">{formatAI3(position.storageFeeDeposit, 4)}</span>
           </div>
           <div>

--- a/apps/web/src/components/positions/PositionSummary.tsx
+++ b/apps/web/src/components/positions/PositionSummary.tsx
@@ -45,9 +45,9 @@ export const PositionSummary: React.FC<PositionSummaryProps> = ({ refreshInterva
       showTooltip: false,
     },
     {
-      label: 'Storage Deposits',
+      label: 'Storage Fund Deposits',
       value: portfolioSummary ? formatAI3(portfolioSummary.totalStorageFee, 4) : '0.0000 AI3',
-      subtitle: 'Total locked in storage fees',
+      subtitle: 'Total locked in storage fund',
       showTooltip: false,
     },
   ];

--- a/apps/web/src/components/staking/StakingForm.tsx
+++ b/apps/web/src/components/staking/StakingForm.tsx
@@ -21,7 +21,7 @@ import {
 interface StakingFormProps {
   operator: Operator;
   onCancel: () => void;
-  onSubmit: (amount: string) => void;
+  onSubmit: (amount: string, txHash?: string) => void;
 }
 
 export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, onSubmit }) => {
@@ -165,14 +165,15 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
 
   // Handle transaction success
   useEffect(() => {
-    if (isSuccess && txHash) {
+    if (isSuccess) {
       // Refresh positions data to show the new pending deposit
       refetchPositions();
+      onSubmit(submittedAmount.current, txHash || undefined);
     }
-  }, [isSuccess, txHash, refetchPositions]);
+  }, [isSuccess, txHash, refetchPositions, onSubmit]);
 
   const handleContinue = () => {
-    onSubmit(submittedAmount.current);
+    onSubmit(submittedAmount.current, txHash || undefined);
   };
 
   return (

--- a/apps/web/src/components/staking/WithdrawalForm.tsx
+++ b/apps/web/src/components/staking/WithdrawalForm.tsx
@@ -142,7 +142,7 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
               </span>
             </div>
             <div className="inline-sm">
-              <span className="text-label text-muted-foreground">Storage Fee Deposit:</span>
+              <span className="text-label text-muted-foreground">Storage Fund Deposit:</span>
               <span className="text-code">{formatAI3(position.storageFeeDeposit, 4)}</span>
             </div>
             <div className="inline-sm">
@@ -318,7 +318,7 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
                 precision: 4,
               },
               {
-                label: 'Storage Fee Refund',
+                label: 'Storage Fund Refund',
                 value: actualStorageFeeRefund,
                 precision: 4,
                 isPositive: true,

--- a/apps/web/src/components/staking/WithdrawalForm.tsx
+++ b/apps/web/src/components/staking/WithdrawalForm.tsx
@@ -13,7 +13,7 @@ import type { UserPosition } from '@/types/position';
 
 interface WithdrawalFormProps {
   position: UserPosition;
-  onSuccess?: (withdrawalAmount: number) => void;
+  onSuccess?: (withdrawalAmount: number, txHash?: string) => void;
   onCancel?: () => void;
 }
 
@@ -36,6 +36,7 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
     estimatedWithdrawalFee,
     estimateWithdrawalFee,
     canExecuteWithdrawal,
+    withdrawalTxHash,
   } = useWithdrawalTransaction();
 
   // Find the operator data for validation
@@ -88,13 +89,14 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
       // Pass the actual gross withdrawal amount to the success callback
       const actualAmount =
         validationResult.actualWithdrawalAmount ?? withdrawalPreview.grossWithdrawalAmount;
-      onSuccess?.(actualAmount);
+      onSuccess?.(actualAmount, withdrawalTxHash || undefined);
     }
   }, [
     withdrawalState,
     onSuccess,
     validationResult.actualWithdrawalAmount,
     withdrawalPreview.grossWithdrawalAmount,
+    withdrawalTxHash,
   ]);
 
   const handleSubmit = async () => {

--- a/apps/web/src/components/transaction/TransactionSuccess.tsx
+++ b/apps/web/src/components/transaction/TransactionSuccess.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { config } from '@/config';
 
 interface TransactionSuccessProps {
   title: string;
@@ -52,7 +53,26 @@ export const TransactionSuccess: React.FC<TransactionSuccessProps> = ({
           {txHash && (
             <div className="p-3 bg-muted/30 rounded-lg">
               <p className="text-label text-muted-foreground mb-1">Transaction Hash</p>
-              <p className="text-code break-all">{txHash}</p>
+              {(() => {
+                const explorerBase = config.explorer?.extrinsicBaseUrl;
+                const shortHash =
+                  txHash.length > 24 ? `${txHash.slice(0, 10)}…${txHash.slice(-10)}` : txHash;
+                return explorerBase ? (
+                  <a
+                    href={`${explorerBase}${txHash}`}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="text-code text-primary hover:underline inline-flex items-center gap-2"
+                    title={txHash}
+                  >
+                    {shortHash}
+                  </a>
+                ) : (
+                  <p className="text-code break-all" title={txHash}>
+                    {shortHash}
+                  </p>
+                );
+              })()}
             </div>
           )}
 

--- a/apps/web/src/config/index.ts
+++ b/apps/web/src/config/index.ts
@@ -17,5 +17,11 @@ export const config = {
     defaultNetworkId: 'mainnet', // Changed from taurus to mainnet
   },
 
+  // Explorer configuration
+  explorer: {
+    extrinsicBaseUrl:
+      import.meta.env.VITE_EXPLORER_EXTRINSIC_BASE_URL || 'https://autonomys.subscan.io/extrinsic/',
+  },
+
   // Add other configuration as needed
 } as const;

--- a/apps/web/src/lib/withdrawal-utils.ts
+++ b/apps/web/src/lib/withdrawal-utils.ts
@@ -21,7 +21,7 @@ export interface WithdrawalValidationResult {
 /**
  * Validate withdrawal amount against minimum nominator stake requirements
  * @param withdrawAmount - Amount user wants to withdraw
- * @param currentStake - Current total stake value (position + storage fee)
+ * @param currentStake - Current total stake value (position + storage fund)
  * @param operator - Operator information containing minimum stake requirements
  * @param isOperator - Whether the user is the operator owner
  * @returns Validation result with warnings
@@ -195,9 +195,9 @@ const formatTimeRemaining = (seconds: number): string => {
 };
 
 /**
- * Calculate storage fee refund based on withdrawal percentage of total position
+ * Calculate storage fund refund based on withdrawal percentage of total position
  * @param withdrawalPercentage - Percentage of position being withdrawn (0-1)
- * @param totalStorageFeeDeposit - Total storage fee deposit for the position
+ * @param totalStorageFeeDeposit - Total storage fund deposit for the position
  * @returns Proportional storage fee refund amount
  */
 export const calculateStorageFeeRefund = (
@@ -232,12 +232,12 @@ export const getWithdrawalPreview = (
 ) => {
   const totalPosition = totalStakePosition + totalStorageFeeDeposit;
 
-  // Calculate percentage based on total position (stake + storage fee)
+  // Calculate percentage based on total position (stake + storage fund)
   const percentage =
     withdrawalType === 'all' ? 100 : Math.min(100, (grossWithdrawalAmount / totalPosition) * 100);
   const withdrawalPercentage = percentage / 100; // Convert to 0-1 range
 
-  // Estimate proportional storage fee refund (actual amount determined by protocol)
+  // Estimate proportional storage fund refund (actual amount determined by protocol)
   // Note: This is an estimate - actual refund depends on storage fund performance
   const estimatedStorageFeeRefund = calculateStorageFeeRefund(
     withdrawalPercentage,
@@ -265,10 +265,10 @@ export const getWithdrawalPreview = (
   return {
     grossWithdrawalAmount: actualGrossWithdrawalAmount, // Total amount user will receive
     netStakeWithdrawal, // Amount withdrawn from staking position
-    storageFeeRefund: estimatedStorageFeeRefund, // Estimated storage fee refund portion
+    storageFeeRefund: estimatedStorageFeeRefund, // Estimated storage fund refund portion
     percentage: Math.round(percentage * 100) / 100, // Round to 2 decimal places
     remainingPosition: remainingStakePosition, // Remaining stake value
-    remainingStorageFee, // Remaining storage fee deposit
+    remainingStorageFee, // Remaining storage fund deposit
     withdrawalType,
   };
 };

--- a/apps/web/src/pages/StakingPage.tsx
+++ b/apps/web/src/pages/StakingPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { OperatorSummary, StakingForm } from '@/components/staking';
+import { TransactionSuccess } from '@/components/transaction';
 import { useOperators } from '@/hooks/use-operators';
 import type { Operator } from '@/types/operator';
 
@@ -15,6 +16,7 @@ export const StakingPage: React.FC = () => {
   const [operator, setOperator] = useState<Operator | null>(null);
   const [stakingSuccess, setStakingSuccess] = useState(false);
   const [stakedAmount, setStakedAmount] = useState<string>('');
+  const [stakingTxHash, setStakingTxHash] = useState<string | null>(null);
 
   // Check if coming from a position (adding more stake)
   const fromPosition = searchParams.get('fromPosition') === 'true';
@@ -26,8 +28,9 @@ export const StakingPage: React.FC = () => {
     }
   }, [operators, operatorId]);
 
-  const handleStakingSubmit = (amount: string) => {
+  const handleStakingSubmit = (amount: string, txHash?: string) => {
     setStakedAmount(amount);
+    setStakingTxHash(txHash || null);
     setStakingSuccess(true);
   };
 
@@ -88,42 +91,15 @@ export const StakingPage: React.FC = () => {
   // Success state
   if (stakingSuccess) {
     return (
-      <div className="py-12 max-w-2xl mx-auto">
-        <Card className="text-center">
-          <CardContent className="pt-8 pb-8">
-            <div className="w-16 h-16 bg-success-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg
-                className="w-8 h-8 text-success-600"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M5 13l4 4L19 7"
-                />
-              </svg>
-            </div>
-            <h2 className="text-2xl font-serif font-bold text-foreground mb-2">
-              Staking Successful!
-            </h2>
-            <p className="text-muted-foreground font-sans mb-6">
-              You have successfully staked {stakedAmount} AI3 to {operator.name}. Your stake will
-              become active after the next epoch transition (~10 minutes).
-            </p>
-            <div className="flex gap-4 justify-center">
-              <Button variant="outline" onClick={handleGoBack} className="font-sans">
-                Browse More Operators
-              </Button>
-              <Button onClick={handleBackToDashboard} className="font-sans">
-                View Dashboard
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
+      <TransactionSuccess
+        title="Staking Successful!"
+        description={`You have successfully staked ${stakedAmount} AI3 to ${operator.name}. Your stake will become active after the next epoch transition (~10 minutes).`}
+        txHash={stakingTxHash ?? undefined}
+        onPrimaryAction={handleBackToDashboard}
+        onSecondaryAction={handleGoBack}
+        primaryActionText="View Dashboard"
+        secondaryActionText="Browse More Operators"
+      />
     );
   }
 

--- a/apps/web/src/pages/WithdrawalPage.tsx
+++ b/apps/web/src/pages/WithdrawalPage.tsx
@@ -58,7 +58,8 @@ export const WithdrawalPage: React.FC = () => {
     navigate('/dashboard');
   };
 
-  const loading = operatorsLoading || positionsLoading;
+  // Only show the loading screen before initial data is available
+  const loading = (operatorsLoading && !operator) || (positionsLoading && !position);
   const hasError = !operator || !position;
 
   // Loading state

--- a/apps/web/src/pages/WithdrawalPage.tsx
+++ b/apps/web/src/pages/WithdrawalPage.tsx
@@ -3,10 +3,10 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { TransactionSuccess } from '@/components/transaction';
 import { WithdrawalForm } from '@/components/staking';
 import { useOperators } from '@/hooks/use-operators';
 import { usePositions } from '@/hooks/use-positions';
-import { TransactionSuccess } from '@/components/transaction';
 import { formatAI3 } from '@/lib/formatting';
 import type { Operator } from '@/types/operator';
 import type { UserPosition } from '@/types/position';
@@ -21,6 +21,7 @@ export const WithdrawalPage: React.FC = () => {
   const [position, setPosition] = useState<UserPosition | null>(null);
   const [withdrawalSuccess, setWithdrawalSuccess] = useState(false);
   const [withdrawnAmount, setWithdrawnAmount] = useState<string>('');
+  const [withdrawalTxHash, setWithdrawalTxHash] = useState<string | null>(null);
 
   useEffect(() => {
     if (operators.length > 0 && operatorId) {
@@ -40,14 +41,15 @@ export const WithdrawalPage: React.FC = () => {
     }
   }, [positions, operatorId]);
 
-  const handleWithdrawalSubmit = (amount: string) => {
+  const handleWithdrawalSubmit = (amount: string, txHash?: string) => {
     setWithdrawnAmount(amount);
+    setWithdrawalTxHash(txHash || null);
     setWithdrawalSuccess(true);
   };
 
-  const handleWithdrawalSuccess = (actualWithdrawalAmount: number) => {
+  const handleWithdrawalSuccess = (actualWithdrawalAmount: number, txHash?: string) => {
     const formattedAmount = formatAI3(actualWithdrawalAmount, 4);
-    handleWithdrawalSubmit(formattedAmount);
+    handleWithdrawalSubmit(formattedAmount, txHash);
   };
 
   const handleBackToDashboard = () => {
@@ -109,12 +111,12 @@ export const WithdrawalPage: React.FC = () => {
     );
   }
 
-  // Success state
   if (withdrawalSuccess) {
     return (
       <TransactionSuccess
         title="Withdrawal Successful!"
         description={`You have successfully withdrawn ${withdrawnAmount} from ${operator!.name}. Your withdrawal will be processed according to the protocol's withdrawal schedule.`}
+        txHash={withdrawalTxHash ?? undefined}
         onPrimaryAction={handleBackToDashboard}
         onSecondaryAction={handleGoBack}
         primaryActionText="View Dashboard"
@@ -145,7 +147,6 @@ export const WithdrawalPage: React.FC = () => {
             <div>
               <h3 className="font-serif font-semibold text-foreground mb-2">Operator</h3>
               <p className="text-lg font-medium">{operator!.name}</p>
-              <p className="text-sm text-muted-foreground">{operator!.description}</p>
             </div>
             <div>
               <h3 className="font-serif font-semibold text-foreground mb-2">Position Value</h3>

--- a/apps/web/src/pages/WithdrawalPage.tsx
+++ b/apps/web/src/pages/WithdrawalPage.tsx
@@ -156,7 +156,9 @@ export const WithdrawalPage: React.FC = () => {
               <p className="text-sm text-muted-foreground">Current stake value</p>
             </div>
             <div>
-              <h3 className="font-serif font-semibold text-foreground mb-2">Storage Fee Deposit</h3>
+              <h3 className="font-serif font-semibold text-foreground mb-2">
+                Storage Fund Deposit
+              </h3>
               <p className="text-xl font-mono font-semibold text-foreground">
                 {formatAI3(position!.storageFeeDeposit, 4)}
               </p>

--- a/apps/web/src/services/position-service.ts
+++ b/apps/web/src/services/position-service.ts
@@ -90,7 +90,7 @@ export const positionService = async (networkId: string = config.network.default
             );
             const storageFeeRefund = shannonsToAI3(withdrawal.storageFeeRefund.toString());
 
-            // Total amount user will receive = net stake + storage fee refund
+            // Total amount user will receive = net stake + storage fund refund
             const grossWithdrawalAmount = stakeWithdrawalAmount + storageFeeRefund;
 
             return {

--- a/apps/web/src/types/position.ts
+++ b/apps/web/src/types/position.ts
@@ -27,7 +27,7 @@ export interface PortfolioSummary {
   totalEarned: number; // Total earnings (requires cost basis calculation)
   pendingDeposits: number; // Count of pending deposit operations
   pendingWithdrawals: number; // Count of pending withdrawal operations
-  totalStorageFee: number; // Total storage fee deposits in AI3 (raw numeric value)
+  totalStorageFee: number; // Total storage fund deposits in AI3 (raw numeric value)
 }
 
 export interface PositionServiceError {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "@polkadot/types-support": "^16.3.1",
     "@polkadot/util": "^13.0.0",
     "@polkadot/util-crypto": "^13.0.0",
-    "@autonomys/auto-consensus": "1.5.10",
-    "@autonomys/auto-utils": "1.5.10",
+    "@autonomys/auto-consensus": "1.5.14",
+    "@autonomys/auto-utils": "1.5.14",
     "ipfs-unixfs": "6.0.9"
   },
   "packageManager": "yarn@4.9.2",

--- a/services/staking-indexer/package.json
+++ b/services/staking-indexer/package.json
@@ -32,8 +32,8 @@
   "license": "MIT",
   "devDependencies": {
     "@apollo/client": "^3.13.5",
-    "@autonomys/auto-consensus": "^1.5.10",
-    "@autonomys/auto-utils": "^1.5.10",
+    "@autonomys/auto-consensus": "1.5.14",
+    "@autonomys/auto-utils": "1.5.14",
     "@polkadot/api": "^16.2.2",
     "@polkadot/types": "^16.3.1",
     "@polkadot/util": "^13.4.3",

--- a/services/staking-worker/package.json
+++ b/services/staking-worker/package.json
@@ -19,8 +19,8 @@
     "staking"
   ],
   "dependencies": {
-    "@autonomys/auto-consensus": "1.5.10",
-    "@autonomys/auto-utils": "1.5.10",
+    "@autonomys/auto-consensus": "1.5.14",
+    "@autonomys/auto-utils": "1.5.14",
     "dotenv": "^16.3.1",
     "ioredis": "^5.3.2",
     "pg": "^8.11.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,8 +98,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@auto-portal/staking-worker@workspace:services/staking-worker"
   dependencies:
-    "@autonomys/auto-consensus": "npm:1.5.10"
-    "@autonomys/auto-utils": "npm:1.5.10"
+    "@autonomys/auto-consensus": "npm:1.5.14"
+    "@autonomys/auto-utils": "npm:1.5.14"
     "@types/ioredis": "npm:^5.0.0"
     "@types/node": "npm:^20.8.9"
     "@types/pg": "npm:^8.10.7"
@@ -117,8 +117,8 @@ __metadata:
   resolution: "@auto-portal/web@workspace:apps/web"
   dependencies:
     "@apollo/client": "npm:^3.8.10"
-    "@autonomys/auto-consensus": "npm:1.5.10"
-    "@autonomys/auto-utils": "npm:1.5.10"
+    "@autonomys/auto-consensus": "npm:1.5.14"
+    "@autonomys/auto-utils": "npm:1.5.14"
     "@polkadot/api": "npm:^16.2.2"
     "@polkadot/extension-dapp": "npm:^0.60.1"
     "@polkadot/extension-inject": "npm:^0.60.1"
@@ -152,22 +152,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@autonomys/auto-consensus@npm:1.5.10":
-  version: 1.5.10
-  resolution: "@autonomys/auto-consensus@npm:1.5.10"
+"@autonomys/auto-consensus@npm:1.5.14":
+  version: 1.5.14
+  resolution: "@autonomys/auto-consensus@npm:1.5.14"
   dependencies:
-    "@autonomys/auto-utils": "npm:^1.5.10"
-  checksum: 10c0/b1675177f59f44297c58e25ceb074a7c59004264bfbbb6b6060856fb343cb1876681eca20440429368838a3a0abf37aaf3e5833165de7405e65eab388de0d8db
+    "@autonomys/auto-utils": "npm:^1.5.14"
+  checksum: 10c0/c3aad302e216f5eedc3c2d97818d4fb2f24051f8c68b85a2efdf5cecc805b94a4241264e977bc6819b2abc8bebdcc8bb08b57dcedac77f87a599a4f882881369
   languageName: node
   linkType: hard
 
-"@autonomys/auto-utils@npm:1.5.10":
-  version: 1.5.10
-  resolution: "@autonomys/auto-utils@npm:1.5.10"
+"@autonomys/auto-utils@npm:1.5.14":
+  version: 1.5.14
+  resolution: "@autonomys/auto-utils@npm:1.5.14"
   dependencies:
     "@polkadot/api": "npm:^15.8.1"
     "@polkadot/extension-dapp": "npm:^0.58.6"
-  checksum: 10c0/9b697ff9c30da30b957ec31e41473cf42de72f4919692cb46aa09502d3a7fbc9e8102d48856a8f2c2f59dd129f1e1bd00c5144621032a75ba409c438e2a17701
+  checksum: 10c0/d1c4d6a38d6b9029191dcae5e777b48717025f30b60f963772ee1d1220f4426cbfa96a27541962024c0dec0ee0a7c4ab35850edb7abbf53a04d8fb3378806951
   languageName: node
   linkType: hard
 
@@ -8241,8 +8241,8 @@ __metadata:
   resolution: "staking@workspace:services/staking-indexer"
   dependencies:
     "@apollo/client": "npm:^3.13.5"
-    "@autonomys/auto-consensus": "npm:^1.5.10"
-    "@autonomys/auto-utils": "npm:^1.5.10"
+    "@autonomys/auto-consensus": "npm:1.5.14"
+    "@autonomys/auto-utils": "npm:1.5.14"
     "@polkadot/api": "npm:^16.2.2"
     "@polkadot/types": "npm:^16.3.1"
     "@polkadot/util": "npm:^13.4.3"


### PR DESCRIPTION
### Summary
- **Terminology alignment**: Replaced “Storage Fee” with “Storage Fund” across UI and helper text.
- **Withdrawal flow fixes**: Pass gross amount for partial withdrawals; SDK computes shares and storage fund refund. More robust fee estimation logic.
- **Transaction visibility**: Surface tx hash post-stake/withdraw and deep-link to explorer (Subscan by default).
- **UX polish**: Improve input handling to avoid accidental value changes; refine loading states; consolidate success UI.

### Motivation
- Align app copy with current protocol semantics (“Storage Fund”).
- Fix incorrect partial-withdraw behavior where net stake amount was being sent instead of gross amount.
- Improve user trust and debuggability by showing transaction hash and linking to an explorer.
- Minor UX improvements for inputs and loading state.

### Key Changes
- **Deps**
  - `@autonomys/auto-consensus` → 1.5.14
  - `@autonomys/auto-utils` → 1.5.14

- **Config**
  - `apps/web/src/config/index.ts`
    - Add `config.explorer.extrinsicBaseUrl` with default `https://autonomys.subscan.io/extrinsic/`
    - Reads `VITE_EXPLORER_EXTRINSIC_BASE_URL` when provided

- **Transactions**
  - `apps/web/src/components/transaction/TransactionSuccess.tsx`
    - Show short tx hash with tooltip for full hash
    - Link to explorer using `config.explorer.extrinsicBaseUrl` if available

- **Staking**
  - `apps/web/src/components/staking/StakingForm.tsx`
    - `onSubmit` now accepts `(amount: string, txHash?: string)`
    - On success: refetch positions and pass tx hash up
  - `apps/web/src/pages/StakingPage.tsx`
    - Handle optional staking tx hash and pass to `TransactionSuccess`

- **Withdrawal**
  - `apps/web/src/components/staking/WithdrawalForm.tsx`
    - `onSuccess?: (withdrawalAmount: number, txHash?: string)`
    - Fee estimation:
      - For `all`: call with `withdrawalType: 'all'`
      - For `partial`: pass gross `amount` directly; SDK handles shares/refund
    - Execute withdraw:
      - For partial: pass gross `amount`
      - For full: omit `amount`
    - Receive and bubble up `withdrawalTxHash`
    - Input improvements: decimal input, disable wheel/arrow-step changes to avoid accidental edits
    - Copy updates to “Storage Fund”
  - `apps/web/src/pages/WithdrawalPage.tsx`
    - Handle optional tx hash and pass to `TransactionSuccess`
    - Loading state now only shows loader before first data resolution
    - Copy updates to “Storage Fund”
  - `apps/web/src/lib/withdrawal-utils.ts`
    - Update docs/copy to “Storage Fund”
    - Clarify calculations as estimates; SDK/protocol is source of truth

- **Copy/Terminology**
  - `OperatorDetailsHeader`, `ActivePositionsTable`, `PositionSummary`, `WithdrawalPage`
    - Replace “Storage Fee” → “Storage Fund”
  - `apps/web/src/services/position-service.ts`
    - Clarify gross withdrawal comment

### Breaking/Attention
- **Prop signature changes**
  - `StakingForm.onSubmit` → `(amount: string, txHash?: string)`
  - `WithdrawalForm.onSuccess` → `(withdrawalAmount: number, txHash?: string)`
  - All known call sites updated (`StakingPage`, `WithdrawalPage`). Verify any external usages if present.

### Env/Config
- Optional explorer override:
  ```
  VITE_EXPLORER_EXTRINSIC_BASE_URL=https://autonomys.subscan.io/extrinsic/
  ```

### Testing Instructions
- **Staking**
  - Stake to any operator
  - On success, verify:
    - Success screen shows short tx hash
    - Link opens correct extrinsic in explorer
    - Positions refresh to show pending/updated state

- **Withdrawal**
  - Partial withdrawal:
    - Enter a valid amount; verify fee estimate runs
    - Confirm success; verify tx hash and explorer link
    - Validate preview math is coherent; SDK should compute shares/refund
  - Full withdrawal:
    - Choose “All”; verify fee estimate runs with `withdrawalType: 'all'`
    - Confirm success and tx hash link
  - Input UX:
    - Scrolling or arrow keys should not change value inadvertently
  - Loading:
    - Loader shows only until operator/position fetched, not after

- **Copy**
  - Throughout the app, verify “Storage Fund” replaces “Storage Fee” where applicable.

### Risks & Rollback
- Depends on SDK 1.5.14 behavior for partial withdrawals (gross amount expected). If issues arise, rollback to previous versions and revert to prior parameter handling.
