### PR TITLE
Simplify staking/withdrawal UI: include storage fund in totals, on-hover breakdowns, cleaner dashboard

### DIFF
--- a/apps/web/src/components/positions/PositionSummary.tsx
+++ b/apps/web/src/components/positions/PositionSummary.tsx
@@ -44,16 +44,10 @@ export const PositionSummary: React.FC<PositionSummaryProps> = ({ refreshInterva
       subtitle: 'Operators staked with',
       showTooltip: false,
     },
-    {
-      label: 'Storage Fund Deposits',
-      value: portfolioSummary ? formatAI3(portfolioSummary.totalStorageFee, 4) : '0.0000 AI3',
-      subtitle: 'Total locked in storage fund',
-      showTooltip: false,
-    },
   ];
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl mx-auto">
       {summaryCards.map(card => (
         <Card key={card.label} className="relative">
           <CardContent className="pt-6">
@@ -92,37 +86,6 @@ export const PositionSummary: React.FC<PositionSummaryProps> = ({ refreshInterva
           </CardContent>
         </Card>
       ))}
-
-      {/* Pending Operations Summary */}
-      {portfolioSummary &&
-        (portfolioSummary.pendingDeposits > 0 || portfolioSummary.pendingWithdrawals > 0) && (
-          <div className="md:col-span-3 mt-4">
-            <Card>
-              <CardContent className="pt-6">
-                <div className="flex items-center justify-center space-x-8 text-sm font-sans">
-                  {portfolioSummary.pendingDeposits > 0 && (
-                    <div className="flex items-center space-x-2">
-                      <div className="w-2 h-2 bg-warning-500 rounded-full animate-pulse"></div>
-                      <span className="text-muted-foreground">
-                        {portfolioSummary.pendingDeposits} pending deposit
-                        {portfolioSummary.pendingDeposits > 1 ? 's' : ''}
-                      </span>
-                    </div>
-                  )}
-                  {portfolioSummary.pendingWithdrawals > 0 && (
-                    <div className="flex items-center space-x-2">
-                      <div className="w-2 h-2 bg-warning-500 rounded-full animate-pulse"></div>
-                      <span className="text-muted-foreground">
-                        {portfolioSummary.pendingWithdrawals} pending withdrawal
-                        {portfolioSummary.pendingWithdrawals > 1 ? 's' : ''}
-                      </span>
-                    </div>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-          </div>
-        )}
     </div>
   );
 };

--- a/apps/web/src/components/staking/StakingForm.tsx
+++ b/apps/web/src/components/staking/StakingForm.tsx
@@ -181,9 +181,9 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
   };
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-stretch">
       {/* Stake Input Form */}
-      <Card>
+      <Card className="h-full">
         <CardHeader>
           <CardTitle className="text-h3">Amount to Stake</CardTitle>
         </CardHeader>
@@ -317,18 +317,24 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
         {formState.showPreview ? (
           <TransactionPreview
             type="staking"
+            className="h-full"
             items={[
               {
-                label: 'Staking Portion',
-                value: calculations.netStaking,
+                label: 'Stake (includes storage fund reserve)',
+                value: calculations.netStaking + calculations.storageFund,
                 precision: 4,
-              },
-              {
-                label: 'Storage Fund (20%)',
-                value: calculations.storageFund,
-                precision: 4,
-                tooltip:
-                  '20% of your stake is reserved as storage fees and refunded proportionally when you withdraw. Actual refund depends on storage fund performance.',
+                tooltip: (
+                  <div className="space-y-1">
+                    <div className="flex justify-between gap-6">
+                      <span>From stake</span>
+                      <span className="font-mono">{formatAI3(calculations.netStaking, 4)}</span>
+                    </div>
+                    <div className="flex justify-between gap-6">
+                      <span>Storage fund reserve</span>
+                      <span className="font-mono">{formatAI3(calculations.storageFund, 4)}</span>
+                    </div>
+                  </div>
+                ),
               },
               {
                 label: 'Transaction Fee',
@@ -360,15 +366,14 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
               )
             }
             notes={[
-              'Storage fund (20%) is held by the protocol and refunded when you withdraw',
-              'Only the net staking amount (80%) earns rewards',
+              'Part of your stake is reserved for storage and refunded when you withdraw',
               'Rewards are automatically compounded to your position',
               'Stake will be active after next epoch transition (~10 minutes)',
               'Your stake will appear as "Pending" until the epoch transition occurs',
             ]}
           />
         ) : (
-          <Card>
+          <Card className="h-full">
             <CardContent className="pt-6">
               <div className="text-center text-muted-foreground">
                 <p className="text-body">Enter an amount to see transaction preview</p>

--- a/apps/web/src/components/staking/WithdrawalForm.tsx
+++ b/apps/web/src/components/staking/WithdrawalForm.tsx
@@ -134,9 +134,9 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
   const showPreview = withdrawalMethod === 'all' || (withdrawalMethod === 'partial' && amount > 0);
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-stretch">
       {/* Withdrawal Input Form */}
-      <Card>
+      <Card className="h-full">
         <CardHeader>
           <CardTitle className="text-h3">Withdraw from {position.operatorName}</CardTitle>
           <div className="stack-xs">
@@ -297,7 +297,7 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
       </Card>
 
       {/* Transaction Preview */}
-      <div>
+      <div className="h-full">
         {showPreview && isValidAmount ? (
           (() => {
             const actualGrossAmount =
@@ -315,20 +315,25 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
               precision?: number;
               isPositive?: boolean;
               isNegative?: boolean;
-              tooltip?: string;
+              tooltip?: React.ReactNode;
             }> = [
               {
-                label: 'Net Stake Withdrawal',
-                value: actualNetAmount,
-                precision: 4,
-              },
-              {
-                label: 'Storage Fund Refund',
-                value: actualStorageFeeRefund,
+                label: 'Withdrawal Amount',
+                value: actualGrossAmount,
                 precision: 4,
                 isPositive: true,
-                tooltip:
-                  'Storage fees are refunded proportionally based on storage fund performance.',
+                tooltip: (
+                  <div className="space-y-1">
+                    <div className="flex justify-between gap-6">
+                      <span>From stake</span>
+                      <span className="font-mono">{formatAI3(actualNetAmount, 4)}</span>
+                    </div>
+                    <div className="flex justify-between gap-6">
+                      <span>Storage refund</span>
+                      <span className="font-mono">{formatAI3(actualStorageFeeRefund, 4)}</span>
+                    </div>
+                  </div>
+                ),
               },
               {
                 label: 'Transaction Fee',
@@ -338,21 +343,8 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
               },
             ];
 
-            if (withdrawalMethod === 'partial' && !validationResult.willWithdrawAll) {
-              withdrawalItems.push({
-                label: 'Remaining Position',
-                value: withdrawalPreview.remainingPosition,
-                precision: 4,
-                tooltip: 'The amount that will remain staked after this withdrawal.',
-              });
-            }
-
             const additionalInfo = (
               <div className="stack-sm">
-                <div className="flex justify-between items-center">
-                  <span className="text-label text-muted-foreground">Operator:</span>
-                  <span className="text-body font-medium">{position.operatorName}</span>
-                </div>
                 <div className="flex justify-between items-center">
                   <span className="text-label text-muted-foreground">Withdrawal Percentage:</span>
                   <span className="text-code font-medium">
@@ -371,9 +363,11 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
             return (
               <TransactionPreview
                 type="withdrawal"
+                className="h-full"
                 items={withdrawalItems}
-                totalLabel="Total to Receive"
+                totalLabel="You will receive"
                 totalValue={actualGrossAmount}
+                totalTooltip={`From stake: ${formatAI3(actualNetAmount, 4)} • Storage refund: ${formatAI3(actualStorageFeeRefund, 4)}`}
                 additionalInfo={additionalInfo}
                 notes={[
                   'Withdrawal requests are processed according to the protocol schedule',
@@ -389,7 +383,7 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
             );
           })()
         ) : (
-          <Card>
+          <Card className="h-full">
             <CardContent className="pt-6">
               <div className="text-center text-muted-foreground">
                 <p className="text-body">

--- a/apps/web/src/components/transaction/TransactionPreview.tsx
+++ b/apps/web/src/components/transaction/TransactionPreview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { InfoIcon } from 'lucide-react';
 import { Tooltip } from '@/components/ui/tooltip';
@@ -9,7 +9,7 @@ type TransactionType = 'staking' | 'withdrawal';
 interface TransactionItem {
   label: string;
   value: number;
-  tooltip?: string;
+  tooltip?: React.ReactNode;
   isPositive?: boolean;
   isNegative?: boolean;
   loading?: boolean;
@@ -23,6 +23,7 @@ interface TransactionPreviewProps {
   totalLabel: string;
   totalValue: number;
   totalLoading?: boolean;
+  totalTooltip?: string;
   additionalInfo?: React.ReactNode;
   notes?: string[];
   className?: string;
@@ -35,12 +36,14 @@ export const TransactionPreview: React.FC<TransactionPreviewProps> = ({
   totalLabel,
   totalValue,
   totalLoading = false,
+  totalTooltip,
   additionalInfo,
   notes,
   className = '',
 }) => {
   const defaultTitle = type === 'staking' ? 'Transaction Breakdown' : 'Withdrawal Summary';
   const displayTitle = title || defaultTitle;
+  const [expanded] = useState(true);
 
   const formatValue = (value: number, precision = 4, loading = false) => {
     if (loading) {
@@ -56,39 +59,52 @@ export const TransactionPreview: React.FC<TransactionPreviewProps> = ({
       </CardHeader>
       <CardContent className="stack-md">
         {/* Transaction Items */}
-        <div className="stack-sm">
-          {items.map((item, index) => (
-            <div key={index} className="flex justify-between items-center">
-              <div className="inline-xs">
-                <span className="text-label text-muted-foreground">{item.label}</span>
-                {item.tooltip && (
-                  <Tooltip content={item.tooltip} side="top">
-                    <InfoIcon className="w-4 h-4 text-muted-foreground cursor-pointer" />
-                  </Tooltip>
-                )}
+        {expanded && (
+          <div className="stack-sm">
+            {items.map((item, index) => (
+              <div key={index} className="flex justify-between items-center">
+                <div className="inline-xs">
+                  {item.tooltip ? (
+                    <Tooltip content={item.tooltip} side="top">
+                      <span className="text-label text-muted-foreground inline-flex items-center gap-1 cursor-pointer">
+                        {item.label}
+                        <InfoIcon className="w-4 h-4 text-muted-foreground" />
+                      </span>
+                    </Tooltip>
+                  ) : (
+                    <span className="text-label text-muted-foreground">{item.label}</span>
+                  )}
+                </div>
+                <span
+                  className={`text-code ${
+                    item.isPositive
+                      ? 'text-success'
+                      : item.isNegative
+                        ? 'text-destructive'
+                        : 'text-foreground'
+                  }`}
+                >
+                  {item.isPositive && '+'}
+                  {formatValue(item.value, item.precision, item.loading)}
+                </span>
               </div>
-              <span
-                className={`text-code ${
-                  item.isPositive
-                    ? 'text-success'
-                    : item.isNegative
-                      ? 'text-destructive'
-                      : 'text-foreground'
-                }`}
-              >
-                {item.isPositive && '+'}
-                {formatValue(item.value, item.precision, item.loading)}
-              </span>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        )}
 
         {/* Divider */}
         <hr className="border-border" />
 
         {/* Total */}
         <div className="flex justify-between items-center">
-          <span className="text-body font-semibold">{totalLabel}</span>
+          <span className="text-body font-semibold inline-flex items-center gap-1">
+            {totalLabel}
+            {totalTooltip && (
+              <Tooltip content={totalTooltip} side="top">
+                <InfoIcon className="w-4 h-4 text-muted-foreground cursor-pointer" />
+              </Tooltip>
+            )}
+          </span>
           <span className="text-code font-bold text-lg">
             {totalLoading ? (
               <span className="animate-pulse text-muted-foreground">Calculating...</span>

--- a/apps/web/src/components/transaction/TransactionPreview.tsx
+++ b/apps/web/src/components/transaction/TransactionPreview.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { InfoIcon } from 'lucide-react';
 import { Tooltip } from '@/components/ui/tooltip';
 import { formatAI3 } from '@/lib/formatting';
+import { getSemanticColors } from '@/lib/design-tokens';
 
 type TransactionType = 'staking' | 'withdrawal';
 
@@ -53,84 +54,91 @@ export const TransactionPreview: React.FC<TransactionPreviewProps> = ({
   };
 
   return (
-    <Card className={className}>
+    <Card className={`h-full flex flex-col ${className}`}>
       <CardHeader>
         <CardTitle className="text-h3">{displayTitle}</CardTitle>
       </CardHeader>
-      <CardContent className="stack-md">
-        {/* Transaction Items */}
-        {expanded && (
-          <div className="stack-sm">
-            {items.map((item, index) => (
-              <div key={index} className="flex justify-between items-center">
-                <div className="inline-xs">
-                  {item.tooltip ? (
-                    <Tooltip content={item.tooltip} side="top">
-                      <span className="text-label text-muted-foreground inline-flex items-center gap-1 cursor-pointer">
-                        {item.label}
-                        <InfoIcon className="w-4 h-4 text-muted-foreground" />
-                      </span>
-                    </Tooltip>
-                  ) : (
-                    <span className="text-label text-muted-foreground">{item.label}</span>
-                  )}
+      <CardContent className="flex h-full flex-col">
+        <div className="flex-1 stack-md">
+          {/* Transaction Items */}
+          {expanded && (
+            <div className="stack-sm">
+              {items.map((item, index) => (
+                <div key={index} className="flex justify-between items-center">
+                  <div className="inline-xs">
+                    {item.tooltip ? (
+                      <Tooltip content={item.tooltip} side="top">
+                        <span className="text-label text-muted-foreground inline-flex items-center gap-1 cursor-pointer">
+                          {item.label}
+                          <InfoIcon className="w-4 h-4 text-muted-foreground" />
+                        </span>
+                      </Tooltip>
+                    ) : (
+                      <span className="text-label text-muted-foreground">{item.label}</span>
+                    )}
+                  </div>
+                  <span
+                    className={`text-code ${
+                      item.isPositive
+                        ? 'text-success'
+                        : item.isNegative
+                          ? 'text-destructive'
+                          : 'text-foreground'
+                    }`}
+                  >
+                    {item.isPositive && '+'}
+                    {formatValue(item.value, item.precision, item.loading)}
+                  </span>
                 </div>
-                <span
-                  className={`text-code ${
-                    item.isPositive
-                      ? 'text-success'
-                      : item.isNegative
-                        ? 'text-destructive'
-                        : 'text-foreground'
-                  }`}
-                >
-                  {item.isPositive && '+'}
-                  {formatValue(item.value, item.precision, item.loading)}
+              ))}
+            </div>
+          )}
+
+          {/* Divider */}
+          <hr className="border-border" />
+
+          {/* Total */}
+          <div className="flex justify-between items-center">
+            <span className="text-body font-semibold inline-flex items-center gap-1">
+              {totalLabel}
+              {totalTooltip && (
+                <Tooltip content={totalTooltip} side="top">
+                  <InfoIcon className="w-4 h-4 text-muted-foreground cursor-pointer" />
+                </Tooltip>
+              )}
+            </span>
+            <span className="text-code font-bold text-lg">
+              {totalLoading ? (
+                <span className="animate-pulse text-muted-foreground">Calculating...</span>
+              ) : (
+                <span className={type === 'withdrawal' ? 'text-success' : 'text-foreground'}>
+                  {type === 'withdrawal' && '+'}
+                  {formatAI3(totalValue, 4)}
                 </span>
-              </div>
-            ))}
+              )}
+            </span>
           </div>
-        )}
 
-        {/* Divider */}
-        <hr className="border-border" />
-
-        {/* Total */}
-        <div className="flex justify-between items-center">
-          <span className="text-body font-semibold inline-flex items-center gap-1">
-            {totalLabel}
-            {totalTooltip && (
-              <Tooltip content={totalTooltip} side="top">
-                <InfoIcon className="w-4 h-4 text-muted-foreground cursor-pointer" />
-              </Tooltip>
-            )}
-          </span>
-          <span className="text-code font-bold text-lg">
-            {totalLoading ? (
-              <span className="animate-pulse text-muted-foreground">Calculating...</span>
-            ) : (
-              <span className={type === 'withdrawal' ? 'text-success' : 'text-foreground'}>
-                {type === 'withdrawal' && '+'}
-                {formatAI3(totalValue, 4)}
-              </span>
-            )}
-          </span>
+          {/* Additional Information */}
+          {additionalInfo && <div className="pt-2">{additionalInfo}</div>}
         </div>
 
-        {/* Additional Information */}
-        {additionalInfo && <div className="pt-2">{additionalInfo}</div>}
-
-        {/* Important Notes */}
-        {notes && notes.length > 0 && (
-          <div className="mt-4 p-4 bg-primary/5 border border-primary/20 rounded-lg">
-            <h4 className="text-label font-semibold text-primary mb-2">Important Notes</h4>
-            <ul className="text-caption text-primary/80 stack-xs">
-              {notes.map((note, index) => (
-                <li key={index}>• {note}</li>
-              ))}
-            </ul>
-          </div>
-        )}
+        {/* Important Notes (uses design tokens, stays inside card) */}
+        {notes &&
+          notes.length > 0 &&
+          (() => {
+            const info = getSemanticColors('info');
+            return (
+              <div className={`mt-4 p-4 rounded-lg border ${info.bg} ${info.border}`}>
+                <h4 className={`text-label font-semibold mb-2 ${info.text}`}>Important Notes</h4>
+                <ul className={`text-caption ${info.subtle} stack-xs`}>
+                  {notes.map((note, index) => (
+                    <li key={index}>• {note}</li>
+                  ))}
+                </ul>
+              </div>
+            );
+          })()}
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -24,14 +24,15 @@ export const Tooltip: React.FC<TooltipProps> = ({ children, content, side = 'top
       onMouseEnter={() => setIsVisible(true)}
       onMouseLeave={() => setIsVisible(false)}
     >
-      {children}
+      <div className="relative z-10">{children}</div>
       {isVisible && (
         <div
           className={cn(
-            'absolute z-50 px-3 py-2 text-xs text-white bg-gray-900 rounded-lg shadow-lg',
+            'absolute z-50 px-3 py-2 text-xs text-white bg-gray-900 rounded-lg shadow-lg w-max whitespace-nowrap max-w-[80vw]',
             sideClasses[side],
             className,
           )}
+          style={{ pointerEvents: 'none' }}
         >
           {content}
           {/* Arrow */}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -15,6 +15,8 @@ export const DashboardPage: React.FC = () => {
   const navigate = useNavigate();
   const { balance, loading: balanceLoading } = useBalance();
   const { hasPositions, portfolioSummary } = usePositions();
+  const hasPendingOperations =
+    (portfolioSummary?.pendingDeposits || 0) + (portfolioSummary?.pendingWithdrawals || 0) > 0;
   const { isConnected } = useWallet();
   const [walletModalOpen, setWalletModalOpen] = useState(false);
 
@@ -171,7 +173,7 @@ export const DashboardPage: React.FC = () => {
       )}
 
       {/* Pending Operations Details */}
-      {isConnected && hasPositions && <PendingOperations />}
+      {isConnected && (hasPositions || hasPendingOperations) && <PendingOperations />}
 
       <WalletModal open={walletModalOpen} onOpenChange={setWalletModalOpen} />
     </div>

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -170,7 +170,7 @@ export const DashboardPage: React.FC = () => {
         </div>
       )}
 
-      {/* Pending Operations */}
+      {/* Pending Operations Details */}
       {isConnected && hasPositions && <PendingOperations />}
 
       <WalletModal open={walletModalOpen} onOpenChange={setWalletModalOpen} />

--- a/apps/web/src/pages/WithdrawalPage.tsx
+++ b/apps/web/src/pages/WithdrawalPage.tsx
@@ -148,21 +148,14 @@ export const WithdrawalPage: React.FC = () => {
               <h3 className="font-serif font-semibold text-foreground mb-2">Operator</h3>
               <p className="text-lg font-medium">{operator!.name}</p>
             </div>
-            <div>
-              <h3 className="font-serif font-semibold text-foreground mb-2">Position Value</h3>
+            <div className="md:col-span-2">
+              <h3 className="font-serif font-semibold text-foreground mb-2">Total Position</h3>
               <p className="text-2xl font-mono font-bold text-foreground">
-                {formatAI3(position!.positionValue, 4)}
+                {formatAI3(position!.positionValue + position!.storageFeeDeposit, 4)}
               </p>
-              <p className="text-sm text-muted-foreground">Current stake value</p>
-            </div>
-            <div>
-              <h3 className="font-serif font-semibold text-foreground mb-2">
-                Storage Fund Deposit
-              </h3>
-              <p className="text-xl font-mono font-semibold text-foreground">
-                {formatAI3(position!.storageFeeDeposit, 4)}
+              <p className="text-sm text-muted-foreground">
+                Includes storage fund; hover breakdown shown in the withdrawal preview
               </p>
-              <p className="text-sm text-muted-foreground">Refundable on withdrawal</p>
             </div>
           </div>
         </CardContent>


### PR DESCRIPTION
# Simplify staking/withdrawal UI: include storage fund in totals, on-hover breakdowns, cleaner dashboard

## Summary

- Treat storage fund as part of totals on primary surfaces. Show the stake/storage split on hover only.
- Simplify staking and withdrawal previews to focus on a single main amount.
- Make left/right columns equal height in staking and withdrawal flows.
- Center dashboard summary cards and remove the redundant storage fund card and summary count box (details component remains).
- Improve tooltip behavior (no clipping, wider, consistent info icon) and use design tokens for notes.

## Why

- Reduce cognitive load: users see one number by default (total or “you will receive”).
- Keep transparency: details are still available via hover tooltips.
- Visual consistency: equal-height columns and centered cards.

## Changes (high-level)

- Staking preview shows one line: “Stake (includes storage fund reserve)” with tooltip breakdown (stake vs reserve).
- Withdrawal preview shows “Withdrawal Amount” with tooltip breakdown (from stake vs storage refund) and a total row “You will receive”.
- Dashboard summary now has two equal-width, centered cards; storage fund summary card removed.
- Restored detailed `PendingOperations` on Dashboard; removed the old summary count box.
- Tooltips widened and layered above card borders; notes styled via design tokens.

## Affected files

- `apps/web/src/components/positions/PositionSummary.tsx`
- `apps/web/src/components/staking/StakingForm.tsx`
- `apps/web/src/components/staking/WithdrawalForm.tsx`
- `apps/web/src/pages/WithdrawalPage.tsx`
- `apps/web/src/pages/DashboardPage.tsx`
- `apps/web/src/components/transaction/TransactionPreview.tsx`
- `apps/web/src/components/ui/tooltip.tsx`

## UX notes

- Primary surfaces show totals only; all storage fund details are discoverable via hover tooltips on the value label (info icon) and on the total.
- Column heights match for a balanced layout.
- Dashboard cards are equal-sized and centered (`md:grid-cols-2`, constrained container).

## Risks

- Tooltips use `pointer-events: none`; interactive content inside a tooltip would need an opt-out in the future.
- Very narrow/wide viewports may prefer tweaking container width (`max-w-5xl`).

## Testing

1. Staking
   - Enter amount; preview shows one “Stake (includes storage fund reserve)”.
   - Hover label → tooltip shows stake vs storage reserve amounts.
   - Cards on left/right align height.
2. Withdrawal
   - Partial and full: preview shows “Withdrawal Amount” and “You will receive”.
   - Hover label or total → breakdown (from stake vs storage refund).
   - Notes remain within the card and use tokenized styling.
3. Dashboard
   - Two centered summary cards; no storage fund card.
   - Detailed `PendingOperations` section still visible below positions.
4. Tooltips
   - Not clipped by card borders; do not wrap awkwardly; align above content.
