### PR TITLE
fix: update color scheme for pending deposits and status indicators to green

### DIFF
--- a/apps/web/src/components/operators/OperatorDetailsHeader.tsx
+++ b/apps/web/src/components/operators/OperatorDetailsHeader.tsx
@@ -112,7 +112,7 @@ export const OperatorDetailsHeader: React.FC<OperatorDetailsHeaderProps> = ({
               {userPosition.pendingDeposit && (
                 <div className="flex justify-between items-center">
                   <span className="text-label text-muted-foreground">Pending:</span>
-                  <span className="text-code font-medium text-warning">
+                  <span className="text-code font-medium text-success">
                     {formatNumber(userPosition.pendingDeposit.amount.toString())} AI3
                   </span>
                 </div>

--- a/apps/web/src/components/positions/ActivePositionsTable.tsx
+++ b/apps/web/src/components/positions/ActivePositionsTable.tsx
@@ -49,7 +49,7 @@ const PositionRow: React.FC<PositionRowProps> = ({
       case 'active':
         return 'text-success-600';
       case 'pending':
-        return 'text-warning-600';
+        return 'text-success-600';
       case 'withdrawing':
         return 'text-warning-600';
       default:
@@ -87,7 +87,7 @@ const PositionRow: React.FC<PositionRowProps> = ({
           <div className="flex gap-4 text-sm">
             {position.pendingDeposit && (
               <div className="flex items-center gap-2">
-                <div className="w-2 h-2 bg-warning-500 rounded-full animate-pulse"></div>
+                <div className="w-2 h-2 bg-success-500 rounded-full animate-pulse"></div>
                 <span className={getStatusColor('pending')}>1 pending deposit</span>
               </div>
             )}

--- a/apps/web/src/components/positions/PendingOperations.tsx
+++ b/apps/web/src/components/positions/PendingOperations.tsx
@@ -35,9 +35,9 @@ interface UnlockableSummaryProps {
 }
 
 const PendingDepositItem: React.FC<PendingDepositItemProps> = ({ deposit, operatorName }) => (
-  <div className="flex items-center justify-between p-3 bg-warning-50 border border-warning-200 rounded-lg">
+  <div className="flex items-center justify-between p-3 bg-success-50 border border-success-200 rounded-lg">
     <div className="flex items-center gap-3">
-      <div className="w-2 h-2 bg-warning-500 rounded-full animate-pulse"></div>
+      <div className="w-2 h-2 bg-success-500 rounded-full animate-pulse"></div>
       <div>
         <div className="font-medium font-sans text-sm">{operatorName}</div>
         <div className="text-xs text-muted-foreground font-sans">
@@ -46,10 +46,10 @@ const PendingDepositItem: React.FC<PendingDepositItemProps> = ({ deposit, operat
       </div>
     </div>
     <div className="text-right">
-      <div className="font-mono font-semibold text-warning-700">
+      <div className="font-mono font-semibold text-success-700">
         +{formatAI3(deposit.amount, 4)}
       </div>
-      <Badge variant="warning" size="sm">
+      <Badge variant="success" size="sm">
         Pending
       </Badge>
     </div>

--- a/apps/web/src/components/positions/PositionBreakdown.tsx
+++ b/apps/web/src/components/positions/PositionBreakdown.tsx
@@ -39,8 +39,8 @@ export const PositionBreakdown: React.FC<PositionBreakdownProps> = ({
           </div>
           {pendingStaked > 0 && (
             <div className="grid grid-cols-2 gap-2">
-              <span className="text-yellow-300 text-left">Pending Staked:</span>
-              <span className="font-mono text-yellow-300 text-right">
+              <span className="text-green-300 text-left">Pending Staked:</span>
+              <span className="font-mono text-green-300 text-right">
                 {formatAI3(pendingStaked, 4)}
               </span>
             </div>
@@ -102,8 +102,8 @@ export const PositionBreakdown: React.FC<PositionBreakdownProps> = ({
           </div>
           {totalPendingStaked > 0 && (
             <div className="grid grid-cols-2 gap-2">
-              <span className="text-yellow-300 text-left">Pending Staked:</span>
-              <span className="font-mono text-yellow-300 text-right">
+              <span className="text-green-300 text-left">Pending Staked:</span>
+              <span className="font-mono text-green-300 text-right">
                 {formatAI3(totalPendingStaked, 4)}
               </span>
             </div>


### PR DESCRIPTION
This pull request updates the color scheme for pending deposit and pending staked indicators across several components to use a green "success" theme instead of a yellow "warning" theme. This change improves the consistency and clarity of the UI by visually aligning pending states with successful outcomes. Closes #78 

**UI Theme Updates:**

* Changed the color of pending deposit indicators from yellow/warning to green/success in `OperatorDetailsHeader.tsx`, `ActivePositionsTable.tsx`, and `PendingOperations.tsx`. This affects text, backgrounds, badges, and status dots. [[1]](diffhunk://#diff-2787d3b8540364bbd8c509be22060d13749a3f74b7d217961efaba8f3048c40dL115-R115) [[2]](diffhunk://#diff-70dc72634f233056871e9b1469dd236c358c407aad6a709d90da266426e0a553L90-R90) [[3]](diffhunk://#diff-06c5a0537d244a55c3e267e61ac005a5c7c84b7a6e88ba2ce41e8ea7c959dccbL38-R40) [[4]](diffhunk://#diff-06c5a0537d244a55c3e267e61ac005a5c7c84b7a6e88ba2ce41e8ea7c959dccbL49-R52)
* Updated the status color for "pending" positions in `ActivePositionsTable.tsx` to use the success color instead of warning.

**Position Breakdown Enhancements:**

* Changed the color for "Pending Staked" values from yellow to green in `PositionBreakdown.tsx`, both for individual and total pending staked amounts. [[1]](diffhunk://#diff-23c353e065d2b59636da8348c4e861192ab63d7c59fd5fd3828ac411014e9763L42-R43) [[2]](diffhunk://#diff-23c353e065d2b59636da8348c4e861192ab63d7c59fd5fd3828ac411014e9763L105-R106)…cross components for improved clarity