### PR TITLE
adjust APY logic for the storage fund percentage

### DIFF
--- a/apps/web/src/components/operators/OperatorCard.tsx
+++ b/apps/web/src/components/operators/OperatorCard.tsx
@@ -66,13 +66,14 @@ export const OperatorCard: React.FC<OperatorCardProps> = ({ operator, onStake, o
                   side="top"
                   content={<ApyTooltip windows={operator.estimatedReturnDetailsWindows} />}
                 >
-                  <div
-                    className={`text-sm font-mono cursor-help ${getAPYColor(
-                      operator.estimatedReturnDetails.annualizedReturn * 100,
-                    )}`}
-                  >
-                    {(operator.estimatedReturnDetails.annualizedReturn * 100).toFixed(2)}%
-                  </div>
+                  {(() => {
+                    const displayApy = operator.estimatedReturnDetails.annualizedReturn * 100;
+                    return (
+                      <div className={`text-sm font-mono cursor-help ${getAPYColor(displayApy)}`}>
+                        {displayApy.toFixed(2)}%
+                      </div>
+                    );
+                  })()}
                 </Tooltip>
               ) : (
                 <div className="text-sm font-mono text-muted-foreground">NA</div>

--- a/apps/web/src/components/operators/OperatorTable.tsx
+++ b/apps/web/src/components/operators/OperatorTable.tsx
@@ -225,13 +225,14 @@ export const OperatorTable: React.FC<OperatorTableProps> = ({
                       side="left"
                       content={<ApyTooltip windows={operator.estimatedReturnDetailsWindows} />}
                     >
-                      <span
-                        className={`font-mono cursor-help ${getAPYColor(
-                          operator.estimatedReturnDetails.annualizedReturn * 100,
-                        )}`}
-                      >
-                        {(operator.estimatedReturnDetails.annualizedReturn * 100).toFixed(2)}%
-                      </span>
+                      {(() => {
+                        const displayApy = operator.estimatedReturnDetails.annualizedReturn * 100;
+                        return (
+                          <span className={`font-mono cursor-help ${getAPYColor(displayApy)}`}>
+                            {displayApy.toFixed(2)}%
+                          </span>
+                        );
+                      })()}
                     </Tooltip>
                   ) : (
                     <span className="text-muted-foreground">NA</span>

--- a/apps/web/src/constants/staking.ts
+++ b/apps/web/src/constants/staking.ts
@@ -1,0 +1,4 @@
+// Staking-related constants
+
+export const STORAGE_FUND_PERCENTAGE = 0.2; // 20% reserved for storage
+export const STAKE_RATIO = 1 - STORAGE_FUND_PERCENTAGE; // Effective staked portion

--- a/apps/web/src/lib/apy.ts
+++ b/apps/web/src/lib/apy.ts
@@ -39,3 +39,29 @@ export const calculateReturnDetails = (
     endDate,
   };
 };
+
+// Adjust returns to account for portion of capital that is actually staked
+import { STAKE_RATIO } from '@/constants/staking';
+
+export const adjustReturnDetailsForStakeRatio = (
+  details: ReturnDetails,
+  stakeRatio: number = STAKE_RATIO,
+): ReturnDetails => ({
+  ...details,
+  periodReturn: details.periodReturn * stakeRatio,
+  annualizedReturn: details.annualizedReturn * stakeRatio,
+});
+
+export type ReturnWindowsKeys = 'd1' | 'd3' | 'd7' | 'd30';
+
+export const adjustReturnDetailsWindowsForStakeRatio = (
+  windows: Partial<Record<ReturnWindowsKeys, ReturnDetails>>,
+  stakeRatio: number = STAKE_RATIO,
+) => {
+  const adjusted: Partial<Record<ReturnWindowsKeys, ReturnDetails>> = {};
+  (['d1', 'd3', 'd7', 'd30'] as ReturnWindowsKeys[]).forEach(key => {
+    const v = windows[key];
+    if (v) adjusted[key] = adjustReturnDetailsForStakeRatio(v, stakeRatio);
+  });
+  return adjusted;
+};

--- a/apps/web/src/lib/staking-utils.ts
+++ b/apps/web/src/lib/staking-utils.ts
@@ -1,9 +1,9 @@
 import type { StakingCalculations, StakingValidation } from '@/types/staking';
 import type { Operator } from '@/types/operator';
 import type { UserPosition } from '@/types/position';
+import { STORAGE_FUND_PERCENTAGE } from '@/constants/staking';
 
 export const TRANSACTION_FEE = 0.0001; // Fallback fee
-const STORAGE_FUND_PERCENTAGE = 0.2; // 20%
 
 export const calculateStakingAmounts = (
   amount: string,

--- a/apps/web/src/services/operator-service.ts
+++ b/apps/web/src/services/operator-service.ts
@@ -5,7 +5,12 @@ import { mapRpcToOperator } from '@/lib/operator-mapper';
 import { TARGET_OPERATORS } from '@/constants/target-operators';
 import { config } from '@/config';
 import indexerService from '@/services/indexer-service';
-import { calculateReturnDetails, type ReturnDetails } from '@/lib/apy';
+import {
+  calculateReturnDetails,
+  adjustReturnDetailsForStakeRatio,
+  adjustReturnDetailsWindowsForStakeRatio,
+  type ReturnDetails,
+} from '@/lib/apy';
 
 export const operatorService = async (networkId: string = config.network.defaultNetworkId) => {
   const api = await getSharedApiConnection(networkId);
@@ -90,7 +95,7 @@ export const operatorService = async (networkId: string = config.network.default
       };
 
       const returnDetails = calculateReturnDetails(startPrice, endPrice);
-      return returnDetails;
+      return returnDetails ? adjustReturnDetailsForStakeRatio(returnDetails) : null;
     } catch (err) {
       console.warn('Failed to estimate APY for operator', operatorId, err);
       return null;
@@ -150,7 +155,7 @@ export const operatorService = async (networkId: string = config.network.default
         }
       });
 
-      return details;
+      return adjustReturnDetailsWindowsForStakeRatio(details) as ReturnDetailsWindows;
     } catch (err) {
       console.warn('Failed to estimate APY windows for operator', operatorId, err);
       return {};


### PR DESCRIPTION
This pull request introduces logic to adjust operator APY (Annual Percentage Yield) calculations so that displayed returns more accurately reflect the portion of capital that is actually staked, accounting for a storage fund reserve. Constants for staking ratios are centralized, and all relevant APY calculations and displays are updated to use the adjusted values. This ensures users see more accurate staking returns in both operator cards and tables.

**Staking ratio logic and constants:**

* Added `STORAGE_FUND_PERCENTAGE` and `STAKE_RATIO` constants to `staking.ts`, centralizing configuration for the portion of capital reserved for storage and the effective staked portion.
* Updated `staking-utils.ts` to import `STORAGE_FUND_PERCENTAGE` from the new constants file, removing the previous hardcoded value.

**APY calculation adjustments:**

* Implemented `adjustReturnDetailsForStakeRatio` and `adjustReturnDetailsWindowsForStakeRatio` in `apy.ts` to adjust APY calculations according to the staking ratio, ensuring all APY-related data reflects only the staked portion.
* Updated `operator-service.ts` to use the new adjustment functions when calculating both single and windowed operator APY values, so all operator data returned by the service is properly adjusted. [[1]](diffhunk://#diff-bd39b642966026f3768bf4c895bc7821b36f61cf1aeba7b40cd0e2d09c0bf821L93-R98) [[2]](diffhunk://#diff-bd39b642966026f3768bf4c895bc7821b36f61cf1aeba7b40cd0e2d09c0bf821L153-R158) [[3]](diffhunk://#diff-bd39b642966026f3768bf4c895bc7821b36f61cf1aeba7b40cd0e2d09c0bf821L8-R13)

**Frontend display updates:**

* Refactored APY display logic in both `OperatorCard.tsx` and `OperatorTable.tsx` to use the adjusted APY values, ensuring users see the correct returns in all UI components. [[1]](diffhunk://#diff-5ed5abf70c9823e59ed259826e7bf9fcc139ffb2bfd7989e812c4add7d8d9012L69-R76) [[2]](diffhunk://#diff-a43fd310198581e62cd31b8f8aa1f4c9028a7c6552e219641eff7e79d6fd5201L228-R235)