### PR TITLE
Add nominator count to operators and declutter operator card

### DIFF
--- a/apps/web/src/components/operators/OperatorCard.tsx
+++ b/apps/web/src/components/operators/OperatorCard.tsx
@@ -56,6 +56,9 @@ export const OperatorCard: React.FC<OperatorCardProps> = ({ operator, onStake, o
             <div>
               <h3 className="text-lg font-semibold text-foreground">{operator.name}</h3>
               <p className="text-sm text-muted-foreground">{operator.domainName}</p>
+              <p className="text-xs text-muted-foreground">
+                {formatPercentage(operator.nominationTax)} tax
+              </p>
             </div>
           </div>
           <div className="flex flex-col items-end space-y-2">
@@ -84,13 +87,7 @@ export const OperatorCard: React.FC<OperatorCardProps> = ({ operator, onStake, o
         </div>
 
         {/* Key Metrics */}
-        <div className="grid grid-cols-3 gap-4 mb-4">
-          <div className="text-center">
-            <div className="text-2xl font-bold font-mono">
-              {formatPercentage(operator.nominationTax)}
-            </div>
-            <div className="text-xs text-muted-foreground">Tax</div>
-          </div>
+        <div className="grid grid-cols-2 gap-4 mb-4">
           <div className="text-center">
             {operator.totalPoolValue ? (
               <Tooltip
@@ -126,7 +123,7 @@ export const OperatorCard: React.FC<OperatorCardProps> = ({ operator, onStake, o
           <div className="mb-4 p-3 bg-muted rounded-lg">
             <div className="text-center">
               <Tooltip content={<PositionBreakdown position={userPosition} />} side="top">
-                <span className="text-sm font-medium text-foreground font-mono cursor-help">
+                <span className="text-sm font-medium text-foreground font-mono cursor-help whitespace-nowrap">
                   {formatAI3(
                     userPosition.positionValue +
                       userPosition.storageFeeDeposit +

--- a/apps/web/src/components/operators/OperatorCard.tsx
+++ b/apps/web/src/components/operators/OperatorCard.tsx
@@ -84,7 +84,7 @@ export const OperatorCard: React.FC<OperatorCardProps> = ({ operator, onStake, o
         </div>
 
         {/* Key Metrics */}
-        <div className="grid grid-cols-2 gap-4 mb-4">
+        <div className="grid grid-cols-3 gap-4 mb-4">
           <div className="text-center">
             <div className="text-2xl font-bold font-mono">
               {formatPercentage(operator.nominationTax)}
@@ -110,6 +110,14 @@ export const OperatorCard: React.FC<OperatorCardProps> = ({ operator, onStake, o
               <div className="text-2xl font-bold font-mono text-muted-foreground">--</div>
             )}
             <div className="text-xs text-muted-foreground">Operator Total Value</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold font-mono">
+              {typeof operator.nominatorCount === 'number'
+                ? formatNumber(operator.nominatorCount)
+                : '--'}
+            </div>
+            <div className="text-xs text-muted-foreground">Nominators</div>
           </div>
         </div>
 

--- a/apps/web/src/components/operators/OperatorTable.tsx
+++ b/apps/web/src/components/operators/OperatorTable.tsx
@@ -161,7 +161,7 @@ export const OperatorTable: React.FC<OperatorTableProps> = ({
               <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[15%]">
                 Total Value
               </th>
-              <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[10%]">
+              <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[8%]">
                 Nominators
               </th>
               <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[8%]">
@@ -170,13 +170,13 @@ export const OperatorTable: React.FC<OperatorTableProps> = ({
               <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[10%]">
                 Est. APY
               </th>
-              <th className="text-center p-3 sm:p-4 font-medium text-muted-foreground w-[8%]">
+              <th className="text-center p-3 sm:p-4 font-medium text-muted-foreground w-[7%]">
                 Status
               </th>
               <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[15%]">
                 Your Position
               </th>
-              <th className="text-center p-3 sm:p-4 font-medium text-muted-foreground w-[24%]">
+              <th className="text-center p-3 sm:p-4 font-medium text-muted-foreground w-[17%]">
                 Actions
               </th>
             </tr>

--- a/apps/web/src/components/operators/OperatorTable.tsx
+++ b/apps/web/src/components/operators/OperatorTable.tsx
@@ -71,6 +71,7 @@ export const OperatorTable: React.FC<OperatorTableProps> = ({
             <tr>
               <th className="text-left p-4 font-medium text-muted-foreground">Operator</th>
               <th className="text-left p-4 font-medium text-muted-foreground">Total Value</th>
+              <th className="text-left p-4 font-medium text-muted-foreground">Nominators</th>
               <th className="text-left p-4 font-medium text-muted-foreground">Tax</th>
               <th className="text-left p-4 font-medium text-muted-foreground">Est. APY</th>
               <th className="text-left p-4 font-medium text-muted-foreground">Status</th>
@@ -92,6 +93,9 @@ export const OperatorTable: React.FC<OperatorTableProps> = ({
                 </td>
                 <td className="p-4">
                   <div className="h-4 bg-muted rounded w-20" />
+                </td>
+                <td className="p-4">
+                  <div className="h-4 bg-muted rounded w-12" />
                 </td>
                 <td className="p-4">
                   <div className="h-4 bg-muted rounded w-12" />
@@ -157,6 +161,9 @@ export const OperatorTable: React.FC<OperatorTableProps> = ({
               <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[15%]">
                 Total Value
               </th>
+              <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[10%]">
+                Nominators
+              </th>
               <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[8%]">
                 Tax
               </th>
@@ -212,6 +219,13 @@ export const OperatorTable: React.FC<OperatorTableProps> = ({
                         {formatNumber(operator.totalPoolValue)} AI3
                       </span>
                     </Tooltip>
+                  ) : (
+                    <span className="text-muted-foreground">--</span>
+                  )}
+                </td>
+                <td className="p-3 sm:p-4 text-right">
+                  {typeof operator.nominatorCount === 'number' ? (
+                    <span className="font-mono">{formatNumber(operator.nominatorCount)}</span>
                   ) : (
                     <span className="text-muted-foreground">--</span>
                   )}

--- a/apps/web/src/components/operators/OperatorTable.tsx
+++ b/apps/web/src/components/operators/OperatorTable.tsx
@@ -66,23 +66,39 @@ export const OperatorTable: React.FC<OperatorTableProps> = ({
   if (loading) {
     return (
       <div className="border border-border rounded-xl overflow-hidden">
-        <table className="w-full">
+        <table className="w-full table-fixed min-w-[1000px]">
           <thead className="bg-muted/50">
             <tr>
-              <th className="text-left p-4 font-medium text-muted-foreground">Operator</th>
-              <th className="text-left p-4 font-medium text-muted-foreground">Total Value</th>
-              <th className="text-left p-4 font-medium text-muted-foreground">Nominators</th>
-              <th className="text-left p-4 font-medium text-muted-foreground">Tax</th>
-              <th className="text-left p-4 font-medium text-muted-foreground">Est. APY</th>
-              <th className="text-left p-4 font-medium text-muted-foreground">Status</th>
-              <th className="text-left p-4 font-medium text-muted-foreground">Your Position</th>
-              <th className="text-left p-4 font-medium text-muted-foreground">Actions</th>
+              <th className="text-left p-3 sm:p-4 font-medium text-muted-foreground w-[20%]">
+                Operator
+              </th>
+              <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[15%]">
+                Total Value
+              </th>
+              <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[8%]">
+                Nominators
+              </th>
+              <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[8%]">
+                Tax
+              </th>
+              <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[10%]">
+                Est. APY
+              </th>
+              <th className="text-center p-3 sm:p-4 font-medium text-muted-foreground w-[7%]">
+                Status
+              </th>
+              <th className="text-right p-3 sm:p-4 font-medium text-muted-foreground w-[15%]">
+                Your Position
+              </th>
+              <th className="text-center p-3 sm:p-4 font-medium text-muted-foreground w-[17%]">
+                Actions
+              </th>
             </tr>
           </thead>
           <tbody>
             {Array.from({ length: 4 }).map((_, index) => (
               <tr key={index} className="border-t border-border animate-pulse">
-                <td className="p-4">
+                <td className="p-3 sm:p-4">
                   <div className="flex items-center space-x-3">
                     <div className="w-8 h-8 bg-muted rounded-full" />
                     <div className="space-y-1">
@@ -91,26 +107,26 @@ export const OperatorTable: React.FC<OperatorTableProps> = ({
                     </div>
                   </div>
                 </td>
-                <td className="p-4">
+                <td className="p-3 sm:p-4 text-right">
                   <div className="h-4 bg-muted rounded w-20" />
                 </td>
-                <td className="p-4">
+                <td className="p-3 sm:p-4 text-right">
                   <div className="h-4 bg-muted rounded w-12" />
                 </td>
-                <td className="p-4">
+                <td className="p-3 sm:p-4 text-right">
                   <div className="h-4 bg-muted rounded w-12" />
                 </td>
-                <td className="p-4">
+                <td className="p-3 sm:p-4 text-right">
                   <div className="h-4 bg-muted rounded w-16" />
                 </td>
-                <td className="p-4">
+                <td className="p-3 sm:p-4 text-center">
                   <div className="h-6 bg-muted rounded w-16" />
                 </td>
-                <td className="p-4">
+                <td className="p-3 sm:p-4 text-right">
                   <div className="h-4 bg-muted rounded w-20" />
                 </td>
-                <td className="p-4">
-                  <div className="flex space-x-2">
+                <td className="p-3 sm:p-4">
+                  <div className="flex space-x-2 justify-center">
                     <div className="h-8 bg-muted rounded w-16" />
                     <div className="h-8 bg-muted rounded w-16" />
                   </div>

--- a/apps/web/src/lib/formatting.ts
+++ b/apps/web/src/lib/formatting.ts
@@ -17,7 +17,8 @@ export const formatNumber = (value: string | number, decimals: number = 0): stri
  */
 export const formatAI3 = (value: string | number, decimals: number = 2): string => {
   const formatted = formatNumber(value, decimals);
-  return `${formatted} AI3`;
+  // Use non-breaking space between value and unit to prevent wrapping
+  return `${formatted}\u00A0AI3`;
 };
 
 /**

--- a/apps/web/src/services/indexer-service.ts
+++ b/apps/web/src/services/indexer-service.ts
@@ -148,6 +148,19 @@ const GET_SHARE_PRICES_UNTIL = gql`
   }
 `;
 
+// GraphQL: aggregate nominator count for an operator (active only)
+const GET_NOMINATOR_COUNT = gql`
+  query GetNominatorCount($operatorId: String!) {
+    staking_nominators_aggregate(
+      where: { operator_id: { _eq: $operatorId }, status: { _eq: "active" } }
+    ) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
 // Service functions
 export const indexerService = {
   // Test connection to indexer
@@ -264,11 +277,35 @@ export const indexerService = {
     }
   },
 
+  // Fetch nominator count for an operator
+  async getNominatorCount(operatorId: string): Promise<number> {
+    try {
+      const result = await getClient().query<{
+        staking_nominators_aggregate: { aggregate: { count: number } };
+      }>({
+        query: GET_NOMINATOR_COUNT,
+        variables: { operatorId },
+        fetchPolicy: 'network-only',
+      });
+
+      return result.data.staking_nominators_aggregate.aggregate.count ?? 0;
+    } catch (error) {
+      console.error('❌ Failed to fetch nominator count:', error);
+      throw error;
+    }
+  },
+
   // Get Apollo Client instance (for direct usage if needed)
   getClient() {
     return getClient();
   },
 };
 
-export { GET_OPERATORS, GET_LATEST_SHARE_PRICES, GET_SHARE_PRICES_SINCE, GET_SHARE_PRICES_UNTIL };
+export {
+  GET_OPERATORS,
+  GET_LATEST_SHARE_PRICES,
+  GET_SHARE_PRICES_SINCE,
+  GET_SHARE_PRICES_UNTIL,
+  GET_NOMINATOR_COUNT,
+};
 export default indexerService;

--- a/apps/web/src/services/indexer-service.ts
+++ b/apps/web/src/services/indexer-service.ts
@@ -288,7 +288,7 @@ export const indexerService = {
         fetchPolicy: 'network-only',
       });
 
-      return result.data.staking_nominators_aggregate.aggregate.count ?? 0;
+      return result.data.staking_nominators_aggregate.aggregate.count;
     } catch (error) {
       console.error('❌ Failed to fetch nominator count:', error);
       throw error;

--- a/apps/web/src/stores/operator-store.ts
+++ b/apps/web/src/stores/operator-store.ts
@@ -93,7 +93,7 @@ export const useOperatorStore = create<OperatorStore>((set, get) => ({
         const idToCount = new Map<string, number>();
         for (const r of countResults) {
           if (r.status === 'fulfilled' && r.value.count !== null) {
-            idToCount.set(r.value.id, r.value.count as number);
+            idToCount.set(r.value.id, r.value.count);
           }
         }
 

--- a/apps/web/src/types/indexer.ts
+++ b/apps/web/src/types/indexer.ts
@@ -106,3 +106,12 @@ export interface OperatorEpochSharePriceRow {
 export interface OperatorEpochSharePricesResponse {
   operator_epoch_share_prices: OperatorEpochSharePriceRow[];
 }
+
+// Aggregate response for staking_nominators count
+export interface NominatorAggregateResponse {
+  staking_nominators_aggregate: {
+    aggregate: {
+      count: number;
+    };
+  };
+}

--- a/apps/web/src/types/operator.ts
+++ b/apps/web/src/types/operator.ts
@@ -20,6 +20,7 @@ export interface Operator {
   // Aggregates
   totalStorageFund?: string; // Operator-level storage fund balance in AI3
   totalPoolValue?: string; // totalStaked + totalStorageFund in AI3
+  nominatorCount?: number; // Active nominators for this operator
 }
 
 export interface OperatorStats {

--- a/infra/staking/Makefile
+++ b/infra/staking/Makefile
@@ -73,8 +73,7 @@ start: setup ## Start services (use 'make start PROFILES=local-node' or ENV=[mai
 	@echo "$(GREEN)✅ Services started$(NC)"
 	@echo "$(BLUE)Waiting for services to be ready...$(NC)"
 	@sleep 5
-	@echo "$(BLUE)Setting up Hasura...$(NC)"
-	@$(MAKE) setup-hasura
+	@echo "$(YELLOW)💡 Next: apply Hasura metadata with: make hasura-restart$(NC)"
 	@echo "$(YELLOW)💡 Check status with: make status$(NC)"
 
 # Start with local node (convenience target)
@@ -91,8 +90,7 @@ start-local: setup ## Start services with local blockchain node (use ENV=dev or 
 	@echo "$(GREEN)✅ Services started with local node$(NC)"
 	@echo "$(BLUE)Waiting for services to be ready...$(NC)"
 	@sleep 5
-	@echo "$(BLUE)Setting up Hasura...$(NC)"
-	@$(MAKE) setup-hasura
+	@echo "$(YELLOW)💡 Next: apply Hasura metadata with: make hasura-restart$(NC)"
 
 # Stop target
 .PHONY: stop
@@ -191,42 +189,50 @@ rebuild: stop build start ## Stop, rebuild, and start services
 
 # Hasura setup
 .PHONY: generate-secret
-generate-secret: ## Generate a secure admin secret for production
+generate-secret: ## Generate a secure Hasura admin secret for production
 	@echo "$(BLUE)Generating secure Hasura admin secret...$(NC)"
 	@openssl rand -hex 32 2>/dev/null || echo "Please install openssl to generate secure secrets"
 	@echo "$(YELLOW)💡 Add this to your .env file as HASURA_GRAPHQL_ADMIN_SECRET$(NC)"
 
-.PHONY: setup-hasura
-setup-hasura: ## Configure Hasura to track all staking tables
+# New: Hasura metadata management
+.PHONY: hasura-apply
+hasura-apply: ## Apply Hasura metadata from ./hasura/metadata to the running instance
 	@if docker compose ps | grep -q "hasura.*Up"; then \
-		echo "$(BLUE)Setting up Hasura GraphQL Engine...$(NC)"; \
-		./scripts/setup-hasura.sh; \
-		echo "$(GREEN)✅ Hasura setup complete$(NC)"; \
-		echo "$(YELLOW)📊 Access points:$(NC)"; \
-		FILE=$(ENV_FILE); \
-		if [ "$$FILE" = ".env" ] && [ -n "$(ENV)" ]; then \
-			if [ -f ".env.$(ENV)" ]; then FILE=".env.$(ENV)"; \
-			elif [ -f ".env.$(ENV).example" ]; then FILE=".env.$(ENV).example"; fi; \
-		fi; \
-		if [ ! -f "$$FILE" ] && [ -f .env ]; then FILE=.env; fi; \
-		if [ -f "$$FILE" ]; then \
-			HASURA_PORT=$$(grep HASURA_GRAPHQL_PORT $$FILE | cut -d'=' -f2 | head -1); \
-			NODE_ENV=$$(grep NODE_ENV $$FILE | cut -d'=' -f2 | head -1); \
-			echo "  • GraphQL: http://localhost:$${HASURA_PORT:-8080}/v1/graphql"; \
-			if [ "$${NODE_ENV:-development}" = "development" ]; then \
-				ADMIN_SECRET=$$(grep HASURA_GRAPHQL_ADMIN_SECRET $$FILE | cut -d'=' -f2 | head -1); \
-				echo "  • Console: http://localhost:$${HASURA_PORT:-8080}/console (password: $${ADMIN_SECRET:-devsecret})"; \
-			else \
-				echo "  • Console: http://localhost:$${HASURA_PORT:-8080}/console (password: [HIDDEN])"; \
-			fi; \
-		else \
-			echo "  • GraphQL: http://localhost:8080/v1/graphql"; \
-			echo "  • Console: http://localhost:8080/console (password: devsecret)"; \
-		fi; \
+		echo "$(BLUE)Applying Hasura metadata...$(NC)"; \
+		docker compose exec hasura sh -lc 'set -e; if command -v hasura-cli >/dev/null 2>&1; then CLI=hasura-cli; elif command -v hasura >/dev/null 2>&1; then CLI=hasura; else echo "hasura CLI not found" >&2; exit 1; fi; $$CLI metadata apply --endpoint http://localhost:8080 --admin-secret "$$HASURA_GRAPHQL_ADMIN_SECRET" --metadata-dir /hasura-metadata'; \
+		echo "$(GREEN)✅ Metadata applied$(NC)"; \
 	else \
-		echo "$(YELLOW)⚠️  Hasura is not running. Skipping setup.$(NC)"; \
-		echo "$(YELLOW)💡 Start services first with: make start$(NC)"; \
-	fi 
+		echo "$(YELLOW)⚠️  Hasura is not running. Start services with: make start$(NC)"; \
+		exit 1; \
+	fi
+
+.PHONY: hasura-reload
+hasura-reload: ## Reload Hasura metadata (refresh caches; does not re-read files)
+	@FILE=$(ENV_FILE); \
+	if [ "$$FILE" = ".env" ] && [ -n "$(ENV)" ]; then \
+		if [ -f ".env.$(ENV)" ]; then FILE=".env.$(ENV)"; \
+		elif [ -f ".env.$(ENV).example" ]; then FILE=".env.$(ENV).example"; fi; \
+	fi; \
+	if [ ! -f "$$FILE" ] && [ -f .env ]; then FILE=.env; fi; \
+	HASURA_PORT=$$(grep HASURA_GRAPHQL_PORT $$FILE | cut -d'=' -f2 | head -1); \
+	ADMIN_SECRET=$$(grep HASURA_GRAPHQL_ADMIN_SECRET $$FILE | cut -d'=' -f2 | head -1); \
+	ADMIN_SECRET=$${ADMIN_SECRET:-devsecret}; \
+	echo "$(BLUE)Reloading Hasura metadata...$(NC)"; \
+	curl -sS -X POST http://localhost:$${HASURA_PORT:-8080}/v1/metadata \
+	  -H 'Content-Type: application/json' \
+	  -H "x-hasura-admin-secret: $$ADMIN_SECRET" \
+	  -d '{"type":"reload_metadata","args":{"reload_remote_schemas":true,"reload_sources":true}}' | cat; \
+	echo "\n$(GREEN)✅ Metadata reloaded$(NC)"
+
+.PHONY: hasura-restart
+hasura-restart: ## Restart Hasura container (re-applies metadata on boot via cli-migrations)
+	@if docker compose ps | grep -q "hasura.*Up"; then \
+		echo "$(BLUE)Restarting Hasura...$(NC)"; \
+		docker compose restart hasura; \
+		echo "$(GREEN)✅ Hasura restarted$(NC)"; \
+	else \
+		echo "$(YELLOW)⚠️  Hasura is not running. Start services with: make start$(NC)"; \
+	fi
 
 # Convenience targets
 .PHONY: start-mainnet start-dev

--- a/infra/staking/hasura/README.md
+++ b/infra/staking/hasura/README.md
@@ -21,12 +21,17 @@ Hasura provides a GraphQL API layer on top of the PostgreSQL database populated 
    docker compose up -d
    ```
 
-2. **Set up Hasura** (track all tables):
+2. **Apply/Reload Metadata**:
 
    ```bash
-   make setup-hasura
-   # or
-   ./scripts/setup-hasura.sh
+   # Apply metadata from repo to running Hasura
+   make hasura-apply
+
+   # Or just reload metadata/caches without changing files
+   make hasura-reload
+
+   # If needed, restart Hasura (cli-migrations image reapplies metadata on boot)
+   make hasura-restart
    ```
 
 3. **Access Hasura Console**:
@@ -114,7 +119,7 @@ Hasura exposes tables exactly as they exist in PostgreSQL with snake_case naming
 ## Development Tips
 
 1. **Use the Console** to explore the schema and test queries
-2. **Export metadata** after making changes:
+2. **Export metadata** after making changes (optional, if CLI available):
    ```bash
    hasura metadata export --endpoint http://localhost:8080 --admin-secret devsecret
    ```
@@ -123,6 +128,6 @@ Hasura exposes tables exactly as they exist in PostgreSQL with snake_case naming
 
 ## Troubleshooting
 
-- **Tables not showing**: Run `make setup-hasura` to track all tables
+- **Tables not showing**: Run `make hasura-apply` then `make hasura-reload`
 - **Permission denied**: Include the admin secret in your requests
 - **Connection refused**: Ensure all services are running with `docker compose ps`

--- a/infra/staking/hasura/metadata/databases/staking/tables/tables.yaml
+++ b/infra/staking/hasura/metadata/databases/staking/tables/tables.yaml
@@ -16,6 +16,12 @@
 - table:
     schema: staking
     name: nominators
+  select_permissions:
+    - role: anonymous
+      permission:
+        columns: '*'
+        filter: {}
+        allow_aggregations: true
 - table:
     schema: staking
     name: nominators_unlocked_events


### PR DESCRIPTION
### Summary

- **What**: Surface the number of active nominators per operator in the web app and streamline the operator card layout.
- **Why**: Improves operator discoverability and decision-making by exposing participation (nominator) signal, while reducing visual noise in the card.

### Changes

- **Indexer/GraphQL**
  - Added aggregate query `GET_NOMINATOR_COUNT` (filters `status = "active"`) in `apps/web/src/services/indexer-service.ts`.
  - Exposed `getNominatorCount(operatorId)` service function.

- **Types**
  - Added `NominatorAggregateResponse` in `apps/web/src/types/indexer.ts`.
  - Extended `Operator` with `nominatorCount?: number` in `apps/web/src/types/operator.ts`.

- **Data/store**
  - Enriched operators in `apps/web/src/stores/operator-store.ts` by fetching nominator counts in the background and merging immutably; re-applies filters after enrichment.

- **UI**
  - `apps/web/src/components/operators/OperatorTable.tsx`: Added “Nominators” column (header, skeleton, and value with fallback `--`).
  - `apps/web/src/components/operators/OperatorCard.tsx`:
    - Header now shows a small muted “{tax}% tax”.
    - Metrics grid shows two tiles: **Operator Total Value** and **Nominators** (order: Total Value first).
    - Preserved fallbacks (`--`) when data is not yet available.

- **Formatting util**
  - `apps/web/src/lib/formatting.ts`: Kept value+unit together using a non-breaking space in `formatAI3`; added optional `formatAI3Compact` helper for future use.

### Implementation notes

- Counting uses `staking_nominators_aggregate` filtered by `operator_id` and `status = "active"`.
- Counts are fetched in parallel after the initial operator list is rendered, mirroring the APY enrichment pattern.
- UI does not block on counts; placeholders render until enrichment completes.

### Screenshots

**Before**
<img width="627" height="348" alt="image" src="https://github.com/user-attachments/assets/d561560a-1d4d-45d6-9265-44add386a84b" />


**After**
<img width="635" height="374" alt="image" src="https://github.com/user-attachments/assets/6e2a29dd-f158-4fbe-9ca0-065d5c624056" />

