### PR TITLE
fix: use light color for apy color when on dark background

### DIFF
--- a/apps/web/src/components/operators/ApyTooltip.tsx
+++ b/apps/web/src/components/operators/ApyTooltip.tsx
@@ -13,7 +13,7 @@ export const ApyTooltip: React.FC<ApyTooltipProps> = ({ windows }) => {
         {label} {isPrimary && '(displayed)'}
       </span>
       <span
-        className={`font-mono ${value !== undefined ? getAPYColor(value) : 'text-white/50'} ${isPrimary ? 'font-semibold' : ''}`}
+        className={`font-mono ${value !== undefined ? getAPYColor(value, { onDark: true }) : 'text-white/50'} ${isPrimary ? 'font-semibold' : ''}`}
       >
         {value !== undefined ? `${value.toFixed(2)}%` : 'NA'}
       </span>

--- a/apps/web/src/lib/formatting.ts
+++ b/apps/web/src/lib/formatting.ts
@@ -48,24 +48,30 @@ export const formatCompactNumber = (value: string | number): string => {
   return formatNumber(num);
 };
 
+interface ApyColorOptions {
+  onDark?: boolean;
+}
+
 /**
  * Get color class for APY values
  */
-export const getAPYColor = (apy: number) => {
+export const getAPYColor = (apy: number, options?: ApyColorOptions) => {
+  const onDark = options?.onDark === true;
   // Use positive color scale as APY increases; avoid implying small positive APY is bad
   if (apy < 0) {
-    return 'text-destructive-600';
+    return onDark ? 'text-error-400' : 'text-error-600';
   }
+  // Neutral for small positive APY; adapt to dark backgrounds
   if (apy < 5) {
-    return 'text-foreground';
+    return onDark ? 'text-white' : 'text-foreground';
   }
   if (apy < 10) {
-    return 'text-success-500';
+    return onDark ? 'text-success-300' : 'text-success-500';
   }
   if (apy < 20) {
-    return 'text-success-600';
+    return onDark ? 'text-success-400' : 'text-success-600';
   }
-  return 'text-success-700';
+  return onDark ? 'text-success-500' : 'text-success-700';
 };
 
 /**


### PR DESCRIPTION
This pull request updates how APY values are color-coded in the UI, making the colors more readable on dark backgrounds. The main change introduces an option to adjust the color scheme for dark backgrounds and applies it to the APY tooltip component.

**APY Color Adaptation:**

* Added an `ApyColorOptions` interface and a new `onDark` option to the `getAPYColor` function in `formatting.ts`, allowing APY colors to be adapted for dark backgrounds.
* Updated the APY color logic in `getAPYColor` to use lighter color variants when `onDark` is true, improving contrast and readability for dark UI elements.

**Component Update:**

* Modified the `ApyTooltip` component to pass the `onDark: true` option to `getAPYColor`, ensuring APY values are displayed with appropriate colors on dark backgrounds.