### PR TITLE
Implement github issue 99 and create pull request

### DIFF
--- a/apps/web/src/components/staking/WithdrawalForm.tsx
+++ b/apps/web/src/components/staking/WithdrawalForm.tsx
@@ -9,6 +9,7 @@ import { useWallet } from '@/hooks/use-wallet';
 import { formatAI3 } from '@/lib/formatting';
 import { getWithdrawalPreview, validateWithdrawal } from '@/lib/withdrawal-utils';
 import { TransactionPreview } from '@/components/transaction';
+import { WITHDRAWAL_UNLOCK_BLOCKS, WITHDRAWAL_UNLOCK_HOURS } from '@/constants/staking';
 import type { UserPosition } from '@/types/position';
 
 interface WithdrawalFormProps {
@@ -250,7 +251,8 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
           <Alert variant="warning">
             <AlertDescription>
               <span className="font-medium">Two-step process:</span> After withdrawal request, funds
-              will have a locking period before you can claim them.
+              will have a {WITHDRAWAL_UNLOCK_HOURS}-hour locking period (
+              {WITHDRAWAL_UNLOCK_BLOCKS.toLocaleString()} blocks) before you can claim them.
             </AlertDescription>
           </Alert>
 
@@ -372,7 +374,7 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
                 notes={[
                   'Withdrawal requests are processed according to the protocol schedule',
                   'Storage fee refunds depend on storage fund performance',
-                  'There is a locking period before funds can be claimed',
+                  `There is a ${WITHDRAWAL_UNLOCK_HOURS}-hour locking period (${WITHDRAWAL_UNLOCK_BLOCKS.toLocaleString()} blocks) before funds can be claimed`,
                   validationResult.willWithdrawAll
                     ? 'This will close your entire position due to minimum stake requirements'
                     : withdrawalMethod === 'partial'

--- a/apps/web/src/constants/staking.ts
+++ b/apps/web/src/constants/staking.ts
@@ -2,3 +2,7 @@
 
 export const STORAGE_FUND_PERCENTAGE = 0.2; // 20% reserved for storage
 export const STAKE_RATIO = 1 - STORAGE_FUND_PERCENTAGE; // Effective staked portion
+
+// Withdrawal unlock period (14,400 blocks = 24 hours at 6 seconds per block)
+export const WITHDRAWAL_UNLOCK_BLOCKS = 14400;
+export const WITHDRAWAL_UNLOCK_HOURS = 24;

--- a/apps/web/src/pages/WithdrawalPage.tsx
+++ b/apps/web/src/pages/WithdrawalPage.tsx
@@ -100,7 +100,7 @@ export const WithdrawalPage: React.FC = () => {
     return (
       <TransactionSuccess
         title="Withdrawal Successful!"
-        description={`You have successfully withdrawn ${withdrawnAmount} from ${operator!.name}. Your withdrawal will be processed according to the protocol's withdrawal schedule.`}
+        description={`You have successfully withdrawn ${withdrawnAmount} from ${operator!.name}. Your withdrawal will be available to claim after a 24-hour unlocking period (14,400 blocks).`}
         txHash={withdrawalTxHash ?? undefined}
         onPrimaryAction={() => navigate('/dashboard')}
         onSecondaryAction={() => navigate('/operators')}


### PR DESCRIPTION
Clarify the 14,400 block (24-hour) unlock period for staked fund withdrawals in the UI to improve user transparency.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbf41605-4616-4732-b2e3-b8c7f31fa720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cbf41605-4616-4732-b2e3-b8c7f31fa720">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

