### PR TITLE
Align staking/withdrawal flows, unify operator summary, and clarify minimum stake/withdrawal rules

### DIFF
--- a/apps/web/src/components/staking/AmountInput.tsx
+++ b/apps/web/src/components/staking/AmountInput.tsx
@@ -10,6 +10,10 @@ interface AmountInputProps {
   disabled?: boolean;
   availableBalance?: number;
   estimatedFee?: number;
+  label?: string;
+  unit?: string;
+  placeholder?: string;
+  onMaxClick?: () => void;
 }
 
 export const AmountInput: React.FC<AmountInputProps> = ({
@@ -19,10 +23,18 @@ export const AmountInput: React.FC<AmountInputProps> = ({
   disabled = false,
   availableBalance = 0,
   estimatedFee,
+  label = 'Amount to Stake',
+  unit = 'AI3',
+  placeholder = '0.00',
+  onMaxClick,
 }) => {
   const feeToUse = (estimatedFee ?? TRANSACTION_FEE) * 3;
 
   const handleMaxClick = () => {
+    if (onMaxClick) {
+      onMaxClick();
+      return;
+    }
     // Calculate maximum stakeable amount by subtracting transaction fee from available balance
     // Use estimated fee * 3 as requested to account for fee buffer
     const maxStakeableAmount = Math.max(0, availableBalance - feeToUse);
@@ -39,13 +51,13 @@ export const AmountInput: React.FC<AmountInputProps> = ({
 
   return (
     <div className="stack-sm">
-      <label className="block text-label">Amount to Stake</label>
+      <label className="block text-label">{label}</label>
       <div className="relative">
         <Input
           type="text"
           value={amount}
           onChange={handleInputChange}
-          placeholder="0.00"
+          placeholder={placeholder}
           disabled={disabled}
           className={`text-code text-lg pr-20 ${errors.length > 0 ? 'border-destructive' : ''}`}
         />
@@ -55,12 +67,12 @@ export const AmountInput: React.FC<AmountInputProps> = ({
             variant="outline"
             size="sm"
             onClick={handleMaxClick}
-            disabled={disabled || availableBalance <= feeToUse}
+            disabled={disabled || (!onMaxClick && availableBalance <= feeToUse)}
             className="h-7 px-3 text-caption"
           >
             MAX
           </Button>
-          <span className="text-muted-foreground text-code">AI3</span>
+          <span className="text-muted-foreground text-code">{unit}</span>
         </div>
       </div>
       {errors.length > 0 && (

--- a/apps/web/src/components/staking/StakingForm.tsx
+++ b/apps/web/src/components/staking/StakingForm.tsx
@@ -3,7 +3,9 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { AmountInput } from './AmountInput';
+//
 import { TransactionPreview } from '@/components/transaction';
+//
 import { useBalance } from '@/hooks/use-balance';
 import { usePositions, useOperatorPosition } from '@/hooks/use-positions';
 import { useStakingTransaction } from '@/hooks/use-staking-transaction';
@@ -45,7 +47,6 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
   } = useStakingTransaction();
   const submittedAmount = useRef('');
   const currentAmount = useRef(0);
-
   const [formState, setFormState] = useState<StakingFormState>({
     amount: '',
     isValid: false,
@@ -183,26 +184,11 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-stretch">
       {/* Stake Input Form */}
-      <Card className="h-full">
+      <Card className="h-full flex flex-col">
         <CardHeader>
           <CardTitle className="text-h3">Amount to Stake</CardTitle>
         </CardHeader>
-        <CardContent className="stack-lg">
-          {/* Current Position Info */}
-          {currentPosition && currentPosition.positionValue > 0 && (
-            <div className="p-4 bg-success/10 border border-success/20 rounded-lg">
-              <div className="flex justify-between items-center">
-                <span className="text-label text-muted-foreground">Current Position</span>
-                <span className="text-code font-semibold text-success">
-                  {formatAI3(currentPosition.positionValue + currentPosition.storageFeeDeposit)}
-                </span>
-              </div>
-              <p className="text-body-small text-muted-foreground mt-1">
-                You can stake any amount for subsequent nominations
-              </p>
-            </div>
-          )}
-
+        <CardContent className="stack-lg flex flex-col flex-1">
           {/* Wallet Connection Alert */}
           {!isConnected && (
             <Alert variant="warning">
@@ -212,20 +198,35 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
             </Alert>
           )}
 
-          {/* Available Balance */}
-          <div className="p-4 bg-accent/10 rounded-lg">
+          {/* Available Balance (aligned with Current Position) */}
+          <div className="flex justify-between items-center">
+            <span className="text-label text-muted-foreground">Available Balance</span>
+            <span className="text-code font-semibold">
+              {balanceLoading ? (
+                <span className="animate-pulse">Loading...</span>
+              ) : balance ? (
+                formatAI3(balance.free)
+              ) : (
+                <span className="text-warning-700">Wallet not connected</span>
+              )}
+            </span>
+          </div>
+
+          {/* Minimum Stake */}
+          <div className="stack-xs">
             <div className="flex justify-between items-center">
-              <span className="text-label text-muted-foreground">Available Balance</span>
+              <span className="text-label text-muted-foreground">Minimum stake</span>
               <span className="text-code font-semibold">
-                {balanceLoading ? (
-                  <span className="animate-pulse">Loading...</span>
-                ) : balance ? (
-                  formatAI3(balance.free)
-                ) : (
-                  <span className="text-warning-700">Wallet not connected</span>
-                )}
+                {formatAI3(parseFloat(operator.minimumNominatorStake), 4)}
               </span>
             </div>
+            {(currentPosition?.positionValue ?? 0) > 0 ? (
+              <p className="text-caption text-muted-foreground">
+                The minimum stake has already been met
+              </p>
+            ) : (
+              <p className="text-caption text-muted-foreground">Applies to first stake only</p>
+            )}
           </div>
 
           {/* Amount Input */}
@@ -271,7 +272,7 @@ export const StakingForm: React.FC<StakingFormProps> = ({ operator, onCancel, on
           )}
 
           {/* Action Buttons */}
-          <div className="inline-md pt-4">
+          <div className="inline-md pt-4 mt-auto">
             {isSuccess ? (
               // Success state buttons
               <>

--- a/apps/web/src/components/staking/WithdrawalForm.tsx
+++ b/apps/web/src/components/staking/WithdrawalForm.tsx
@@ -210,9 +210,10 @@ export const WithdrawalForm: React.FC<WithdrawalFormProps> = ({
               disabled={withdrawalState === 'signing' || withdrawalState === 'pending'}
               label="Total Amount to Receive"
               unit="AI3"
-              onMaxClick={() =>
-                setAmount(String(position.positionValue + position.storageFeeDeposit))
-              }
+              onMaxClick={() => {
+                setWithdrawalMethod('all');
+                setAmount('');
+              }}
             />
           )}
 

--- a/apps/web/src/pages/WithdrawalPage.tsx
+++ b/apps/web/src/pages/WithdrawalPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { TransactionSuccess } from '@/components/transaction';
-import { WithdrawalForm } from '@/components/staking';
+import { WithdrawalForm, OperatorSummary } from '@/components/staking';
 import { useOperators } from '@/hooks/use-operators';
 import { usePositions } from '@/hooks/use-positions';
 import { formatAI3 } from '@/lib/formatting';
@@ -84,7 +84,7 @@ export const WithdrawalPage: React.FC = () => {
           <CardContent className="pt-6">
             <div className="text-center">
               <p className="text-destructive font-sans">
-                {!operator ? 'Operator not found' : 'Position not found'}
+                Error: {!operator ? 'Operator not found' : 'Position not found'}
               </p>
               <Button variant="outline" onClick={handleGoBack} className="mt-4 font-sans">
                 Back to Dashboard
@@ -120,26 +120,8 @@ export const WithdrawalPage: React.FC = () => {
         </h1>
       </div>
 
-      {/* Position Summary */}
-      <Card className="mb-8">
-        <CardContent className="pt-6">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div>
-              <h3 className="font-serif font-semibold text-foreground mb-2">Operator</h3>
-              <p className="text-lg font-medium">{operator!.name}</p>
-            </div>
-            <div className="md:col-span-2">
-              <h3 className="font-serif font-semibold text-foreground mb-2">Total Position</h3>
-              <p className="text-2xl font-mono font-bold text-foreground">
-                {formatAI3(position!.positionValue + position!.storageFeeDeposit, 4)}
-              </p>
-              <p className="text-sm text-muted-foreground">
-                Includes storage fund; hover breakdown shown in the withdrawal preview
-              </p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Operator Summary */}
+      <OperatorSummary operator={operator!} />
 
       {/* Withdrawal Form */}
       <WithdrawalForm


### PR DESCRIPTION
### Summary

- Align Staking and Withdrawal forms for consistent layout and behavior
- Update `OperatorSummary` to match `OperatorCard` fields and tooltips
- Generalize `AmountInput` and reuse it across forms
- Add Minimum stake guidance to both forms with contextual notes
- Prevent action buttons from jumping by pinning them to the bottom of cards
- Reflect forced full withdrawal when remaining < minimum in the withdrawal summary

### Key Changes

- `AmountInput`: added label/unit/placeholder/onMaxClick for reuse
- `OperatorSummary`: now mirrors `OperatorCard` (header, Est. APY tooltip, operator value, nominators, and your position with breakdown)
- `StakingForm`: removed in-form position panel; added min stake row & note; aligned available balance layout; anchored actions
- `WithdrawalForm`: added min stake row & note; summary title becomes “Full Withdrawal Summary” when required; anchored actions

### Why

- Improve clarity and consistency across staking/withdrawal user journeys
- Reduce duplication and centralize operator info presentation
- Make minimum stake rules explicit at the point of action

### How to Test

1. Stake to an operator with no existing position: note minimum stake guidance; verify staking works and success screen appears.
2. Stake to the same operator again: note that the minimum stake note indicates it’s already met.
3. Withdraw partially so that remaining would be below minimum: withdrawal summary title reads “Full Withdrawal Summary”; note indicates full close.
4. Withdraw partially leaving remaining above minimum: summary remains a partial withdrawal.
5. Verify tooltips on `OperatorSummary` (APY, operator value, your total position) and alignment with `OperatorCard`.

Closes #99 