### PR TITLE
feat: update TARGET_OPERATORS to include additional operators

### DIFF
--- a/apps/web/src/constants/target-operators.ts
+++ b/apps/web/src/constants/target-operators.ts
@@ -1,3 +1,4 @@
 // Target operators for mainnet
-// These are the 2 available operators on mainnet
-export const TARGET_OPERATORS = ['0', '1'];
+// These are the 4 currently available operators on mainnet
+// TODO: Remove this once we have indexer in place
+export const TARGET_OPERATORS = ['0', '1', '2', '3'];


### PR DESCRIPTION
This pull request updates the list of available operators on mainnet in the `TARGET_OPERATORS` constant. The change temporarily expands the set of operators from two to four, with a note to remove this adjustment once the indexer is in place.

Mainnet operator configuration:

* Expanded `TARGET_OPERATORS` in `apps/web/src/constants/target-operators.ts` from `['0', '1']` to `['0', '1', '2', '3']` to reflect the four currently available operators on mainnet. Added a TODO comment indicating this is a temporary change until the indexer is implemented.