### PR TITLE
Add dark mode

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,6 +5,20 @@
     <link rel="icon" type="image/svg+xml" href="/autonomys-icon-dark.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Stake your AI3 tokens with trusted operators on the Autonomys Network. Discover validators, manage your staking positions, and earn rewards securely." />
+    <script>
+      // Prevent theme FOUC by applying class before React mounts
+      (function() {
+        try {
+          var key = 'theme';
+          var raw = localStorage.getItem(key);
+          var pref = (raw && JSON.parse(raw).state && JSON.parse(raw).state.preference) || 'system';
+          var isDark = pref === 'dark' || (pref === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+          var root = document.documentElement;
+          if (isDark) root.classList.add('dark'); else root.classList.remove('dark');
+          root.style.colorScheme = isDark ? 'dark' : 'light';
+        } catch (_) {}
+      })();
+    </script>
     <title>Autonomys Staking</title>
   </head>
   <body>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,9 +2,19 @@ import { RouterProvider } from 'react-router-dom';
 import { ApolloProvider } from '@apollo/client';
 import { router } from './router';
 import indexerService from './services/indexer-service';
+import { useEffect } from 'react';
+import { useThemeStore } from '@/stores/theme-store';
 
-export const App = () => (
-  <ApolloProvider client={indexerService.getClient()}>
-    <RouterProvider router={router} />
-  </ApolloProvider>
-);
+export const App = () => {
+  const initializeTheme = useThemeStore(s => s.initializeTheme);
+
+  useEffect(() => {
+    initializeTheme();
+  }, [initializeTheme]);
+
+  return (
+    <ApolloProvider client={indexerService.getClient()}>
+      <RouterProvider router={router} />
+    </ApolloProvider>
+  );
+};

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { layout } from '@/lib/layout';
 import { config } from '@/config';
 import { getNetworkBadge, type BadgeVariant } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
+import { ThemeToggle } from '@/components/theme-toggle';
 
 interface HeaderProps {
   className?: string;
@@ -53,7 +54,7 @@ export const Header: React.FC<HeaderProps> = ({ className = '' }) => {
             </NavLink>
           </nav>
 
-          {/* Wallet Connection and Network Badge */}
+          {/* Wallet Connection, Theme, and Network Badge */}
           <div className={layout.inline('md') + ' items-center gap-3'}>
             {(() => {
               const netId = config.network.defaultNetworkId;
@@ -64,6 +65,7 @@ export const Header: React.FC<HeaderProps> = ({ className = '' }) => {
                 </Badge>
               );
             })()}
+            <ThemeToggle />
             <WalletButton onOpenModal={() => setWalletModalOpen(true)} />
           </div>
         </div>

--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Moon, Sun, Laptop } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip } from '@/components/ui/tooltip';
+import { useThemeStore, type ThemePreference } from '@/stores/theme-store';
+
+const labelMap: Record<ThemePreference, string> = {
+  light: 'Light mode',
+  dark: 'Dark mode',
+  system: 'System theme',
+} as const;
+
+export const ThemeToggle: React.FC = () => {
+  const preference = useThemeStore(s => s.preference);
+  const isDarkMode = useThemeStore(s => s.isDarkMode);
+  const cyclePreference = useThemeStore(s => s.cyclePreference);
+
+  const renderIcon = () => {
+    if (preference === 'system') return <Laptop className="size-4" />;
+    return isDarkMode ? <Moon className="size-4" /> : <Sun className="size-4" />;
+  };
+
+  return (
+    <Tooltip content={`Theme: ${labelMap[preference]}`}>
+      <Button
+        variant="ghost"
+        size="icon"
+        aria-label={`Toggle theme (current: ${labelMap[preference]})`}
+        onClick={cyclePreference}
+      >
+        {renderIcon()}
+      </Button>
+    </Tooltip>
+  );
+};
+

--- a/apps/web/src/stores/theme-store.ts
+++ b/apps/web/src/stores/theme-store.ts
@@ -1,0 +1,99 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type ThemePreference = 'light' | 'dark' | 'system';
+
+interface ThemeState {
+  preference: ThemePreference;
+  isDarkMode: boolean;
+  setPreference: (preference: ThemePreference) => void;
+  cyclePreference: () => void;
+  applyThemeToDocument: (doc?: Document) => void;
+  initializeTheme: () => void;
+}
+
+const THEME_STORAGE_KEY = 'theme';
+
+const getSystemPrefersDark = () =>
+  typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+const computeIsDark = (preference: ThemePreference) =>
+  preference === 'dark' || (preference === 'system' && getSystemPrefersDark());
+
+const applyClassToDocument = (isDark: boolean, doc: Document = document) => {
+  const root = doc.documentElement;
+  root.classList.toggle('dark', isDark);
+  // Improve native form controls and scrollbars
+  (root as HTMLElement).style.colorScheme = isDark ? 'dark' : 'light';
+};
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set, get) => ({
+      preference: 'system',
+      isDarkMode: false,
+
+      setPreference: (preference: ThemePreference) => {
+        set({ preference });
+        const isDark = computeIsDark(preference);
+        set({ isDarkMode: isDark });
+        try {
+          applyClassToDocument(isDark);
+        } catch (error) {
+          // no-op in non-browser environments
+        }
+      },
+
+      cyclePreference: () => {
+        const order: ThemePreference[] = ['light', 'dark', 'system'];
+        const current = get().preference;
+        const next = order[(order.indexOf(current) + 1) % order.length];
+        get().setPreference(next);
+      },
+
+      applyThemeToDocument: (doc?: Document) => {
+        const isDark = computeIsDark(get().preference);
+        set({ isDarkMode: isDark });
+        try {
+          applyClassToDocument(isDark, doc ?? document);
+        } catch (error) {
+          // ignore if document is not available
+        }
+      },
+
+      initializeTheme: () => {
+        // Apply immediately based on persisted/system preference
+        get().applyThemeToDocument();
+
+        // React to system changes when preference is system
+        if (typeof window !== 'undefined') {
+          const media = window.matchMedia('(prefers-color-scheme: dark)');
+          const handler = () => {
+            if (get().preference === 'system') {
+              const isDark = media.matches;
+              set({ isDarkMode: isDark });
+              try {
+                applyClassToDocument(isDark);
+              } catch (error) {
+                // ignore
+              }
+            }
+          };
+
+          try {
+            media.addEventListener('change', handler);
+          } catch {
+            // Fallback for Safari
+            // @ts-expect-error legacy API
+            media.addListener(handler);
+          }
+        }
+      },
+    }),
+    {
+      name: THEME_STORAGE_KEY,
+      partialize: state => ({ preference: state.preference }),
+    },
+  ),
+);
+


### PR DESCRIPTION
This pull request introduces a robust theme management system to the web app, allowing users to toggle between light, dark, and system themes. It prevents Flash of Unstyled Content (FOUC) by applying the theme before React mounts, adds a theme toggle button to the header, and centralizes theme state management with a persistent store that responds to system preference changes.

**Theme management improvements:**

* Added a `theme-store` (`apps/web/src/stores/theme-store.ts`) using Zustand with persistence, supporting light/dark/system preferences, automatic system change detection, and document class updates.
* Injected a script into `index.html` to immediately apply the correct theme class and color scheme before React mounts, preventing FOUC.

**UI enhancements:**

* Added a `ThemeToggle` component (`apps/web/src/components/theme-toggle.tsx`) with tooltip and icon to allow users to cycle theme preference.
* Included the `ThemeToggle` in the header next to wallet and network controls (`apps/web/src/components/layout/Header.tsx`). [[1]](diffhunk://#diff-45372e9df55617ae7a3ea950e2d5681bb9dbd9be3ff162c659ed48d071252cf4R8) [[2]](diffhunk://#diff-45372e9df55617ae7a3ea950e2d5681bb9dbd9be3ff162c659ed48d071252cf4L56-R57) [[3]](diffhunk://#diff-45372e9df55617ae7a3ea950e2d5681bb9dbd9be3ff162c659ed48d071252cf4R68)

**App initialization:**

* Updated `App.tsx` to initialize the theme store and apply the theme on mount, ensuring React respects the persisted/system preference.